### PR TITLE
Add OSX as a working platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ latest tarball.
 
 ### Build Requirements
 
+#### Linux
+
 On a fresh Ubuntu install, you will need to install these:
 
-```
+```bash
 $ apt install build-essential scons python3 python3-pip curl git
 $ pip3 install virtualenv --user
 ```
@@ -51,13 +53,27 @@ deb-src http://archive.ubuntu.com/ubuntu/ artful main
  
 and instruct apt to install the needed packages:
 
-```
+```bash
 $ apt update
 $ apt build-dep python3.6
 ```
 
 See the [Python Developer's Guide](https://devguide.python.org/setup/#build-dependencies) 
 for instructions on additional platforms.
+
+#### MacOS
+
+With MacOS, you will need XCode installed and install the command line tools. 
+
+```
+$ xcode-select --install
+```
+
+If you are using CPython as your backend, you will need openssl. To install with Homebrew:
+
+```
+$ brew install opensll
+```
 
 ### Running the build
 
@@ -68,7 +84,7 @@ From your `godot-python` directory:
 godot-python$ scons platform=x11-64 backend=cpython release
 ```
 
-Valid platforms are `x11-64`, `x11-32`, `windows-64`, `windows-32`. Check Travis 
+Valid platforms are `x11-64`, `x11-32`, `windows-64`, `windows-32` and `osx-64`. Check Travis 
 or Appveyor links above to see the current status of your platform.
 
 Valid backends are `cpython`, `pypy`.
@@ -79,6 +95,14 @@ download a pinned pypy release binary or checkout cpython, move to a pinned
 commit and build cpython from source. It will generate the CFFI bindings and 
 compile the shared library for your platform. The output of this command 
 is a zip file which are shared on the release page.
+
+#### MacOS Adttional Requirement
+
+For MacOS, you will need to customize our cpp to use clang. Your final command will look like:
+
+```bash
+godot-python$ scons platform=osx-64 backend=cpython gdnative_parse_cpp="clang -E" release
+```
 
 ### Testing your build
 

--- a/SConstruct
+++ b/SConstruct
@@ -25,6 +25,7 @@ vars.Add(EnumVariable('platform', "Target platform", '', allowed_values=(
     'x11-32',
     'windows-64',
     'windows-32',
+    'osx-64',
 )))
 vars.Add(BoolVariable('show_build_dir', "Display build dir and leave", False))
 vars.Add('release_suffix', "Suffix to add to the release archive", 'wip')

--- a/platforms/osx-64/SCsub
+++ b/platforms/osx-64/SCsub
@@ -1,0 +1,179 @@
+from __future__ import print_function
+import os, glob, shutil
+from SCons.Errors import UserError
+
+
+Import('env')
+
+
+env['bits'] = '64'
+env['build_dir'] = Dir('#build/osx-64-%s' % env['backend'])
+env.Append(CFLAGS='-m64')
+env.Append(LINKFLAGS='-m64')
+
+
+### Godot binary (to run tests) ###
+
+
+if not env['godot_binary']:
+    env['godot_binary'] = File('godot.osx.opt.debug.fat')
+    env.Command(env['godot_binary'], None,
+        'curl -L %s/godot.osx.opt.debug.fat -o ${TARGET} && chmod 750 ${TARGET}' %
+            env['godot_release_base_url']
+    )
+    env.NoClean(env['godot_binary'])
+
+
+### GDnative stuff ###
+
+
+if not env['gdnative_include_dir']:
+    env['gdnative_include_dir'] = Dir('../gdnative/include')
+if not env['gdnative_wrapper_lib']:
+    env['gdnative_wrapper_lib'] = File('../gdnative/libgdnative_wrapper_code.osx.opt.debug.fat.a')
+    env.Command(env['gdnative_wrapper_lib'], None,
+        'curl -L %s/libgdnative_wrapper_code.osx.opt.fat.a -o ${TARGET}' %
+            env['godot_release_base_url']
+    )
+    env.NoClean(env['gdnative_wrapper_lib'])
+
+
+### Python interpreter ###
+
+
+if env['backend'] == 'cpython':
+    cpython_src = Dir('cpython')
+    env.Command(cpython_src, None,
+        "git clone https://github.com/python/cpython.git --depth=1 --branch=v3.6.3 --single-branch ${TARGET}"
+    )
+    env.NoClean(cpython_src)
+
+    cpython_build = Dir('cpython_build')
+    # TODO: allow to compile cpython with `--with-pydebug` ?
+    # Compile CPython and install cffi through pip
+    env.Command(cpython_build, cpython_src,
+        "cd ${SOURCE} && " +
+        "echo Configuring CPython... && "
+        "1>/dev/null ./configure --enable-shared --prefix=${TARGET.get_abspath()} CPPFLAGS=\"-I/usr/local/opt/openssl/include\" LDFLAGS=\"-L/usr/local/opt/openssl/lib\" && " +
+        "echo Building CPython... && "
+        "1>/dev/null make -j4 && " +
+        "echo Installing CPython in ${TARGET.get_abspath()}... && "
+        "1>/dev/null make install && " +
+        "LD_LIBRARY_PATH=${TARGET.get_abspath()}/lib ${TARGET.get_abspath()}/bin/pip3 install cffi"
+    )
+    env.NoClean(cpython_build)
+
+    def generate_build_dir(target, source, env):
+        target = target[0]
+        cpython_build = source[0]
+        libpythonscript = source[1]
+        godot_embedded = source[2]
+
+        if os.path.isdir(target.path):
+            shutil.rmtree(target.path)
+        os.mkdir(target.path)
+
+        def c(subpath=''):
+            return os.path.join(cpython_build.abspath, *subpath.split('/'))
+
+        def p(subpath=''):
+            return os.path.join(target.abspath, 'pythonscript', *subpath.split('/'))
+
+        os.mkdir(p())
+
+        shutil.copy(libpythonscript.path, p())
+        open(p('.gdignore'), 'w').close()
+
+        if os.path.isdir(c('include')):
+            # Windows build of CPython doesn't contain include dir
+            shutil.copytree(c('include'), p('include'))
+
+        # Remove __pycache__ to save lots of space
+        for root, dirs, files in os.walk(c('lib')):
+            if '__pycache__' in dirs:
+                shutil.rmtree(os.path.join(root, '__pycache__'))
+
+        shutil.copytree(c('bin'), p('bin'))
+
+        shutil.copytree(c('lib'), p('lib'))
+        if env['compressed_stdlib']:
+            shutil.move(p('lib/python3.6'), p('lib/tmp_python3.6'))
+            os.mkdir(p('lib/python3.6'))
+            shutil.move(p('lib/tmp_python3.6/lib-dynload'), p('lib/python3.6/lib-dynload'))
+            shutil.move(p('lib/tmp_python3.6/site-packages'), p('lib/python3.6/site-packages'))
+            shutil.make_archive(
+                base_name=p('lib/python36'),
+                format='zip',
+                root_dir=p('lib/tmp_python3.6'),
+            )
+            shutil.rmtree(p('lib/tmp_python3.6'))
+
+        if env['dev_dyn']:
+            os.symlink(godot_embedded.abspath, p('lib/python3.6/site-packages/godot'))
+        else:
+            shutil.copytree(godot_embedded.path, p('lib/python3.6/site-packages/godot'))
+
+        if 'generate_build_dir_hook' in env:
+            env['generate_build_dir_hook'](target.abspath)
+
+    env['generate_build_dir'] = generate_build_dir
+    env['backend_dir'] = cpython_build
+    env.Append(CFLAGS='-DBACKEND_CPYTHON')
+    env.Append(CFLAGS='-I %s/include/python3.6m/' % cpython_build.path)
+    env.Append(LIBPATH='%s/lib' % cpython_build.path)
+    env.Append(LIBS=['python3.6m'])
+    env.Append(LINKFLAGS=["-Wl,-rpath,'$$ORIGIN/lib'"])
+
+else:  # pypy
+    
+    PYPY_SRC_NAME = 'pypy3-v5.10.0-osx64'
+    PYPY_SRC_ARCHIVE = '%s.tar.bz2' % PYPY_SRC_NAME
+    PYPY_SRC_ARCHIVE_URL = 'https://bitbucket.org/pypy/pypy/downloads/%s' % PYPY_SRC_ARCHIVE
+
+    pypy_build = Dir(PYPY_SRC_NAME)
+
+    env.Command(PYPY_SRC_ARCHIVE, None,
+        "curl -L %s -o ${TARGET}" % PYPY_SRC_ARCHIVE_URL
+    )
+    env.NoClean(PYPY_SRC_ARCHIVE)
+    env.Command(pypy_build, PYPY_SRC_ARCHIVE,
+        "tar xf ${SOURCE} -C ${TARGET.srcdir}"
+    )
+
+    def generate_build_dir(target, source, env):
+        target = target[0]
+        pypy_build = source[0]
+        libpythonscript = source[1]
+        godot_embedded = source[2]
+
+        if os.path.isdir(target.path):
+            shutil.rmtree(target.path)
+        os.mkdir(target.path)
+
+        def c(subpath=''):
+            return os.path.join(pypy_build.abspath, *subpath.split('/'))
+
+        def p(subpath=''):
+            return os.path.join(target.abspath, 'pythonscript', *subpath.split('/'))
+
+        shutil.copytree(c(), p())
+        os.unlink(p('LICENSE'))
+        os.unlink(p('README.rst'))
+        shutil.copy(libpythonscript.path, p())
+        open(p('.gdignore'), 'w').close()
+
+        if env['dev_dyn']:
+            os.symlink(godot_embedded.abspath, p('site-packages/godot'))
+        else:
+            shutil.copytree(godot_embedded.path, p('site-packages/godot'))
+
+        if 'generate_build_dir_hook' in env:
+            env['generate_build_dir_hook'](target.abspath)
+
+    env['generate_build_dir'] = generate_build_dir
+    env['backend_dir'] = pypy_build
+    env.Append(CFLAGS='-DBACKEND_PYPY')
+    env.Append(CFLAGS='-I %s/include' % pypy_build.path)
+    env.Append(LIBPATH='%s/bin' % pypy_build.path)
+    env.Append(LIBS=['pypy3-c'])
+    env.Append(LINKFLAGS=["-Wl,-rpath,'$$ORIGIN/bin'"])


### PR DESCRIPTION
I've never set up Travis for OSX so I haven't looked into that yet - but everything else is working wonderfully. Tests all pass. 

Biggest difference from x11-64 (other than some string changes for downloads) are including openssl paths when building cpython and needing to use `clang -E` instead of `cpp`. 