### PR TITLE
Add support for optional arguments. TypeError messages same as python's

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Contributors
 * Max Hilbrunner `@mhilbrunner <https://github.com/mhilbrunner>`_
 * Chris Ridenour `@cridenour <https://github.com/cridenour>`_
 * Gary Oberbrunner `@garyo <https://github.com/garyo>`_
+* Paolo Barresi `@paolobb4 <https://github.com/paolobb4>`_

--- a/pythonscript/embedded/godot/hazmat/lazy_bindings.py
+++ b/pythonscript/embedded/godot/hazmat/lazy_bindings.py
@@ -230,10 +230,34 @@ def build_method(classname, meth):
         rettype = meth['return']['type']
 
         def bind(self, *args):
-            if len(args) != len(meth['args']):
-                raise TypeError('%s() takes %s positional argument but %s were given' %
-                                (methname, len(meth['args']), len(args)))
-            # TODO: check args number and type here (ptrcall means segfault on bad args...)
+            # check number of args
+            n_args, nm_args, nmd_args = len(args), len(meth['args']), len(meth['default_args'])
+            nr_args = nm_args - nmd_args    # number of required arguments
+            if n_args < nr_args:  # not enough args, raise error
+                if nr_args - n_args == 1:
+                    raise TypeError("{}() missing 1 required positional argument: '{}'".format(
+                                    methname, meth['args'][nr_args-1]['name'])
+                                    )
+                else:
+                    raise TypeError('{}() missing {} required positional arguments: '.format(
+                                        methname, nr_args - n_args)
+                                    + ', '.join("'{}'".format(arg['name']) for arg in meth['args'][n_args:nr_args-1])
+                                    + " and '{}'".format(meth['args'][nr_args-1]['name'])
+                                    )
+            if n_args > nm_args:  # too many args, raise error
+                if nmd_args == 0:
+                    raise TypeError("{}()takes {} positional arguments but {} were given".format(
+                                    methname, nm_args, n_args)
+                                    )
+                else:
+                    raise TypeError("{}() takes from {} to {} positional arguments but {} were given".format(
+                                    methname, nr_args, nm_args, n_args)
+                                    )
+            # complete missing optional args with default values
+            diff = len(args) - len(meth['args'])
+            args += meth['default_args'][diff:]
+
+            # TODO: check args type here (ptrcall means segfault on bad args...)
             # print('[PY->GD] Ptrcall %s.%s (%s) on %s with %s' % (classname, methname, meth, self, args))
             raw_args = [convert_arg(meth_arg['type'], meth_arg['name'], arg)
                         for arg, meth_arg in zip(args, meth['args'])]

--- a/pythonscript/embedded/godot/hazmat/lazy_bindings.py
+++ b/pythonscript/embedded/godot/hazmat/lazy_bindings.py
@@ -235,24 +235,24 @@ def build_method(classname, meth):
             nr_args = nm_args - nmd_args    # number of required arguments
             if n_args < nr_args:  # not enough args, raise error
                 if nr_args - n_args == 1:
-                    raise TypeError("{}() missing 1 required positional argument: '{}'".format(
+                    raise TypeError("%s() missing 1 required positional argument: '%s'" % (
                                     methname, meth['args'][nr_args-1]['name'])
-                                    )
+                    )
                 else:
-                    raise TypeError('{}() missing {} required positional arguments: '.format(
+                    raise TypeError('%s() missing %i required positional arguments: ' % (
                                         methname, nr_args - n_args)
-                                    + ', '.join("'{}'".format(arg['name']) for arg in meth['args'][n_args:nr_args-1])
-                                    + " and '{}'".format(meth['args'][nr_args-1]['name'])
-                                    )
+                                    + ', '.join("'%s'" %(arg['name']) for arg in meth['args'][n_args:nr_args-1])
+                                    + " and '%s'" %(meth['args'][nr_args-1]['name'])
+                    )
             if n_args > nm_args:  # too many args, raise error
                 if nmd_args == 0:
-                    raise TypeError("{}()takes {} positional arguments but {} were given".format(
+                    raise TypeError("%s()takes %i positional arguments but %i were given" % (
                                     methname, nm_args, n_args)
-                                    )
+                    )
                 else:
-                    raise TypeError("{}() takes from {} to {} positional arguments but {} were given".format(
+                    raise TypeError("%s() takes from %i to %i positional arguments but %i were given" % (
                                     methname, nr_args, nm_args, n_args)
-                                    )
+                    )
             # complete missing optional args with default values
             diff = len(args) - len(meth['args'])
             args += meth['default_args'][diff:]


### PR DESCRIPTION
Hi there, I looked into issue #27 wich seamed like a rather important missing feature.

Now, despite the note in that issue about attribute _'default_args'_ being empty I guess some time has passed and that's not the case anymore so I used that and made it possible to leave optional arguments implicit, although I haven't looked into support for using keyword arguments yet.

I also changed the TypeError messages to be the same as python's default TypeError messages when passing too many or too few arguments to a function.