### PR TITLE
Fix link target of libpython on OSX

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors
 * Chris Ridenour `@cridenour <https://github.com/cridenour>`_
 * Gary Oberbrunner `@garyo <https://github.com/garyo>`_
 * Paolo Barresi `@paolobb4 <https://github.com/paolobb4>`_
+* Colin Kinloch `@ColinKinloch <https://github.com/ColinKinloch>`_

--- a/platforms/osx-64/SCsub
+++ b/platforms/osx-64/SCsub
@@ -62,13 +62,18 @@ if env["backend"] == "cpython":
     env.Command(
         cpython_build,
         cpython_src,
-        "cd ${SOURCE} && " + "echo Configuring CPython... && "
-        '1>/dev/null ./configure --enable-shared --prefix=${TARGET.get_abspath()} CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib" && '
-        + "echo Building CPython... && "
-        "1>/dev/null make -j4 && "
-        + "echo Installing CPython in ${TARGET.get_abspath()}... && "
-        "1>/dev/null make install && "
-        + "LD_LIBRARY_PATH=${TARGET.get_abspath()}/lib ${TARGET.get_abspath()}/bin/pip3 install cffi",
+        [
+          "cd ${SOURCE} && " + "echo Configuring CPython... && "
+          '1>/dev/null ./configure --enable-shared --prefix=${TARGET.get_abspath()} CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib" && '
+          + "echo Building CPython... && "
+          "1>/dev/null make -j4 && "
+          + "echo Installing CPython in ${TARGET.get_abspath()}... && "
+          "1>/dev/null make install && "
+          + "LD_LIBRARY_PATH=${TARGET.get_abspath()}/lib ${TARGET.get_abspath()}/bin/pip3 install cffi",
+          Chmod("%s/lib/libpython3.6m.dylib" % cpython_build.abspath, 0600),
+          "install_name_tool -id @loader_path/lib/libpython3.6m.dylib " +
+          "%s/lib/libpython3.6m.dylib" % cpython_build.abspath
+        ]
     )
     env.NoClean(cpython_build)
 

--- a/platforms/osx-64/SCsub
+++ b/platforms/osx-64/SCsub
@@ -63,16 +63,16 @@ if env["backend"] == "cpython":
         cpython_build,
         cpython_src,
         [
-          "cd ${SOURCE} && " + "echo Configuring CPython... && "
-          '1>/dev/null ./configure --enable-shared --prefix=${TARGET.get_abspath()} CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib" && '
-          + "echo Building CPython... && "
-          "1>/dev/null make -j4 && "
-          + "echo Installing CPython in ${TARGET.get_abspath()}... && "
-          "1>/dev/null make install && "
-          + "LD_LIBRARY_PATH=${TARGET.get_abspath()}/lib ${TARGET.get_abspath()}/bin/pip3 install cffi",
-          Chmod("%s/lib/libpython3.6m.dylib" % cpython_build.abspath, 0600),
-          "install_name_tool -id @loader_path/lib/libpython3.6m.dylib " +
-          "%s/lib/libpython3.6m.dylib" % cpython_build.abspath
+            "cd ${SOURCE} && " + "echo Configuring CPython... && "
+            '1>/dev/null ./configure --enable-shared --prefix=${TARGET.get_abspath()} CPPFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib" && '
+            + "echo Building CPython... && "
+            "1>/dev/null make -j4 && "
+            + "echo Installing CPython in ${TARGET.get_abspath()}... && "
+            "1>/dev/null make install && "
+            + "LD_LIBRARY_PATH=${TARGET.get_abspath()}/lib ${TARGET.get_abspath()}/bin/pip3 install cffi",
+            Chmod("%s/lib/libpython3.6m.dylib" % cpython_build.abspath, 0600),
+            "install_name_tool -id @loader_path/lib/libpython3.6m.dylib " +
+            "%s/lib/libpython3.6m.dylib" % cpython_build.abspath
         ]
     )
     env.NoClean(cpython_build)
@@ -154,7 +154,15 @@ else:  # pypy
         PYPY_SRC_ARCHIVE, None, "curl -L %s -o ${TARGET}" % PYPY_SRC_ARCHIVE_URL
     )
     env.NoClean(PYPY_SRC_ARCHIVE)
-    env.Command(pypy_build, PYPY_SRC_ARCHIVE, "tar xf ${SOURCE} -C ${TARGET.srcdir}")
+    env.Command(
+        pypy_build,
+        PYPY_SRC_ARCHIVE,
+        [
+            "tar xf ${SOURCE} -C ${TARGET.srcdir}",
+            "install_name_tool -id @loader_path/bin/libpypy3-c.dylib " +
+            "%s/bin/libpypy3-c.dylib" % pypy_build.abspath
+        ]
+    )
 
     def generate_build_dir(target, source, env):
         target = target[0]


### PR DESCRIPTION
Fix for #76.
Use "install_name_tool" to change link target of libpython from "/Users/travis/build/touilleMan/godot-python/platforms/osx-64/cpython_build/lib/libpython3.6m.dylib" to "@loader_path/lib/libpython3.6m.dylib".