### PR TITLE
Static binding generation

### DIFF
--- a/tools/generate_godot_bindings_module.py
+++ b/tools/generate_godot_bindings_module.py
@@ -57,8 +57,6 @@ def generate_godot_bindings(api, pretty=True, no_docstring=False):
     for cls_api in api["content"]:
         if cls_api["name"] == "GlobalConstants":
             constants = cls_api["constants"]
-        elif cls_api["singleton"]:
-            singletons.append(cls_api)
         else:
             classes.append(cls_api)
 

--- a/tools/templates/class.j2
+++ b/tools/templates/class.j2
@@ -3,7 +3,7 @@
 
 {% macro render_class(cls) -%}
 
-class {{ cls.name | fix_name }}:
+class {{ cls.name | fix_name }}({{ cls.base_class | fix_name }}):
     {{ render_docstring(cls.name) | indent(width=4) }}
 
 {%- for constant_name, constant_value in cls.constants.items() -%}

--- a/tools/templates/module.j2
+++ b/tools/templates/module.j2
@@ -37,10 +37,13 @@ __GODOT_API_VERSION__ = '{{ godot_api_version }}'
 # Classes
 {% for cls in classes %}
 
-
+{% if cls.singleton %}
+{{ render_singleton(cls) }}
+{% else %}
 {{ render_class(cls) }}
+{% endif %}
 
-{%- endfor %}
+{% endfor %}
 
 
 # Globals constants
@@ -51,8 +54,5 @@ __GODOT_API_VERSION__ = '{{ godot_api_version }}'
 
 # Singletons
 {% for singleton in singletons %}
-
-
-{{ render_singleton(singleton) }}
 
 {%- endfor -%}


### PR DESCRIPTION
* Singleton handling moved to a template. 
* Added safe ordering of classes based on inheritance, and added inheritance for classes.

Btw I noticed that singletons can be inherited, but inherited classes are not singletons.
```
  {
   "name": "IP",
   "base_class": "Object",
   "api_type": "core",
   "singleton": true,
   "instanciable": false,
   "is_reference": false,
...
```

```
  {
   "name": "IP_Unix",
   "base_class": "IP",
   "api_type": "core",
   "singleton": false,
   "instanciable": false,
   "is_reference": false,
   "constants": {},
   "properties": [],
   "signals": [],
   "methods": [],
   "enums": []
  },
```