### PR TITLE
Fix ptrcall with float and int type arguments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,30 +2,31 @@ image: Visual Studio 2017
 
 environment:
   VS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+  MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
   CPP: clang -E
   matrix:
     - TARGET_PLATFORM: windows-64
       ARCH: amd64
       TARGET_BACKEND: cpython
-      PYTHON: C:\Python36-x64
+      PYTHON: C:\Python37-x64
     - TARGET_PLATFORM: windows-32
       ARCH: amd64_x86
       TARGET_BACKEND: cpython
-      PYTHON: C:\Python36
+      PYTHON: C:\Python37
     # Pypy doesn't support windows 64bits
     # - TARGET_PLATFORM: windows-64
     #   ARCH: amd64
     #   TARGET_BACKEND: pypy
-    #   PYTHON: C:\Python36-x64
+    #   PYTHON: C:\Python37-x64
     - TARGET_PLATFORM: windows-32
       ARCH: amd64_x86
       TARGET_BACKEND: pypy
-      PYTHON: C:\Python36
+      PYTHON: C:\Python37
 
 matrix:
   allow_failures:
     # TODO: ask Armin why pypy includes are not provided within the release...
-    - env: TARGET_PLATFORM=windows-32 ARCH=amd64_x86 TARGET_BACKEND=pypy PYTHON=C:\Python36
+    - env: TARGET_PLATFORM=windows-32 ARCH=amd64_x86 TARGET_BACKEND=pypy PYTHON=C:\Python37
 
 install:
   - set "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -34,6 +35,7 @@ install:
   - pip install wheel
   - pip install scons
   - if defined VS call "%VS%" %ARCH%  # if defined - so we can also use mingw
+  - set "MSBUILD_PATH=%MSBUILD%"
 
 before_build:
   - git rev-parse HEAD

--- a/pythonscript/embedded/godot/hazmat/allocator.py
+++ b/pythonscript/embedded/godot/hazmat/allocator.py
@@ -28,8 +28,8 @@ def alloc_with_destructor_factory(type, constructor, destructor):
 
 # Simplest types
 godot_bool_alloc = partial(ffi.new, "godot_bool*")
-godot_int_alloc = partial(ffi.new, "godot_int*")
-godot_real_alloc = partial(ffi.new, "godot_real*")
+godot_int_alloc = partial(ffi.new, "long long*")
+godot_real_alloc = partial(ffi.new, "double*")
 godot_object_alloc = partial(ffi.new, "godot_object**")
 # Allocation of struct with no destructor
 godot_vector3_alloc = partial(ffi.new, "godot_vector3*")


### PR DESCRIPTION
Hi

ptrcall with arguments of float and int are currently not working properly.
ptrcall(read) of float and int should use 64 bit type.

Please see this thread.
https://github.com/godotengine/godot/pull/24113

Thanks