### PR TITLE
Implement godot_string_to_pyobj, pyobj_to_godot_string

### DIFF
--- a/pythonscript/godot_hazmat/_bootstrap_editor.pxi
+++ b/pythonscript/godot_hazmat/_bootstrap_editor.pxi
@@ -5,6 +5,7 @@ from libc.stddef cimport wchar_t
 
 cdef extern from "Python.h":
     PyObject* PyUnicode_FromWideChar(wchar_t *w, Py_ssize_t size)
+    wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *)
 
 from .gdnative_api_struct cimport (
     godot_pluginscript_language_data,
@@ -28,8 +29,12 @@ cdef object godot_string_to_pyobj(const godot_string *p_gdstr):
 
 cdef godot_string pyobj_to_godot_string(object pystr):
     cdef godot_string gdstr;
+
+    cdef Py_ssize_t length
+    cdef wchar_t *my_wchars = PyUnicode_AsWideCharString(pystr, &length)
+    
     gdapi.godot_string_new_with_wide_string(
-        &gdstr, <wchar_t*><char*>pystr, len(pystr)
+        &gdstr, my_wchars, length
     )
     return gdstr
 

--- a/pythonscript/godot_hazmat/_bootstrap_editor.pxi
+++ b/pythonscript/godot_hazmat/_bootstrap_editor.pxi
@@ -1,6 +1,10 @@
 # cython: c_string_type=unicode, c_string_encoding=utf8
 
+from cpython.ref cimport PyObject 
 from libc.stddef cimport wchar_t
+
+cdef extern from "Python.h":
+    PyObject* PyUnicode_FromWideChar(wchar_t *w, Py_ssize_t size)
 
 from .gdnative_api_struct cimport (
     godot_pluginscript_language_data,
@@ -17,7 +21,9 @@ from .gdapi cimport gdapi
 
 
 cdef object godot_string_to_pyobj(const godot_string *p_gdstr):
-    return <char*>gdapi.godot_string_wide_str(p_gdstr)
+    cdef const wchar_t * result = gdapi.godot_string_wide_str(p_gdstr)
+    cdef PyObject * pystr = PyUnicode_FromWideChar(result, -1)
+    return <object>pystr
 
 
 cdef godot_string pyobj_to_godot_string(object pystr):


### PR DESCRIPTION
I did not find any more cythonic solution for converting wchar_t to godot_string

But I'm getting this error after using PyUnicode_FromWideChar(...)
```
pythonscript\godot_hazmat\_bootstrap.c: In function '__Pyx_ImportType':
pythonscript\godot_hazmat\_bootstrap.c:4060:13: error: unknown conversion type character 'z' in format [-Werror=format=]
             "%s.%s size changed, may indicate binary incompatibility. "
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pythonscript\godot_hazmat\_bootstrap.c:4061:24: note: format string is defined here
             "Expected %zd from C header, got %zd from PyObject",
                        ^
```
with **MinGW-W64 GCC-7.2.0** on Windows

I can disable this warning with
`-Wno-format`

Did you experience this issue?