### PR TITLE
Make sure constructor is not NULL when trying to instantiate a class

### DIFF
--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -105,6 +105,13 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
     def new():
         # Call to __new__ bypasses __init__ constructor
         cdef {{ cls["name"] }} wrapper = {{ cls["name"] }}.__new__({{ cls["name"] }})
+        
+        # For some reason, for some specific classes (e.g. OpenSimplexNoise), the constructor is NULL.
+        # It seems some classes are not loaded/available at import time.
+        global __{{ cls["name"] }}_constructor
+        if not __{{ cls["name"] }}_constructor:
+            __{{ cls["name"] }}_constructor = gdapi10.godot_get_class_constructor("{{ cls['name'] }}")
+        
         wrapper._gd_ptr = __{{ cls["name"] }}_constructor()
         if wrapper._gd_ptr is NULL:
             raise MemoryError

--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -112,6 +112,9 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
         if not __{{ cls["name"] }}_constructor:
             __{{ cls["name"] }}_constructor = gdapi10.godot_get_class_constructor("{{ cls['name'] }}")
         
+        if not __{{ cls["name"] }}_constructor:
+            raise NotImplementedError("No constructor found for class {{ cls["name"] }}")
+        
         wrapper._gd_ptr = __{{ cls["name"] }}_constructor()
         if wrapper._gd_ptr is NULL:
             raise MemoryError

--- a/tools/bindings_templates/method.tmpl.pyx
+++ b/tools/bindings_templates/method.tmpl.pyx
@@ -111,13 +111,16 @@ cdef {{ binding_type }} {{ retval }} = {{ binding_type }}.__new__({{ binding_typ
 cdef {{ method["return_type"] }} {{ retval }}
 {% set retval_as_arg = "&{}".format(retval) %}
 {% endif %}
+
 global {{ get_method_bind_register_name(cls, method) }}
 if {{ get_method_bind_register_name(cls, method) }} == NULL:
     # Method is sometimes NULL because it is not loaded/available at import time (when godot_method_bind_get_method gets called the first time)
     # So we must try to get it again to make sure it actually is not implemented, or was just not available previously.
     {{ get_method_bind_register_name(cls, method) }} = gdapi10.godot_method_bind_get_method("{{ cls['bind_register_name'] }}", "{{ method['name'] }}")
-    if {{ get_method_bind_register_name(cls, method) }} == NULL:
-        raise NotImplementedError
+
+if {{ get_method_bind_register_name(cls, method) }} == NULL:
+    raise NotImplementedError("Method not available ({{ cls["name"] }}.{{ method["name"] }})")
+
 gdapi10.godot_method_bind_ptrcall(
     {{ get_method_bind_register_name(cls, method) }},
     self._gd_ptr,


### PR DESCRIPTION
For some specific classes (e.g. OpenSimplexNoise), the constructor is NULL. It appears as some classes are not available at import time, and a simple check for the existance of the constructor fixes the problem.