### PR TITLE
Fix Method Calls

### DIFF
--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -105,6 +105,13 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
     def new():
         # Call to __new__ bypasses __init__ constructor
         cdef {{ cls["name"] }} wrapper = {{ cls["name"] }}.__new__({{ cls["name"] }})
+        
+        # For some reason, for some specific classes (e.g. OpenSimplexNoise), the constructor is NULL.
+        # It seems some classes are not loaded/available at import time.
+        global __{{ cls["name"] }}_constructor
+        if not __{{ cls["name"] }}_constructor:
+            __{{ cls["name"] }}_constructor = gdapi10.godot_get_class_constructor("{{ cls['name'] }}")
+        
         wrapper._gd_ptr = __{{ cls["name"] }}_constructor()
         if wrapper._gd_ptr is NULL:
             raise MemoryError

--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -112,6 +112,9 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
         if not __{{ cls["name"] }}_constructor:
             __{{ cls["name"] }}_constructor = gdapi10.godot_get_class_constructor("{{ cls['name'] }}")
         
+        if not __{{ cls["name"] }}_constructor:
+            raise NotImplementedError("No constructor found for class {{ cls["name"] }}")
+        
         wrapper._gd_ptr = __{{ cls["name"] }}_constructor()
         if wrapper._gd_ptr is NULL:
             raise MemoryError

--- a/tools/bindings_templates/method.tmpl.pyx
+++ b/tools/bindings_templates/method.tmpl.pyx
@@ -25,7 +25,7 @@ cdef godot_method_bind *{{ get_method_bind_register_name(cls, method) }} = gdapi
 {%- else %}
  {{ arg["type_specs"]["binding_type"] }} {{ arg["name"] }}
 {%- if not arg["type_specs"]["is_base_type"] and not (arg["has_default_value"] and arg["default_value"] == "None") %}
-  not None ## if default value is NULL, none should be allowed
+  not None {## if default value is NULL, none should be allowed#}
 {%- endif %}
 {%- endif %}
 {%- if arg["has_default_value"] %}
@@ -70,7 +70,7 @@ cdef GDString __gdstr_{{ arg["name"] }} = ensure_is_gdstring({{ arg["name"] }})
 cdef NodePath __nodepath_{{ arg["name"] }} = ensure_is_nodepath({{ arg["name"] }})
 {{ argsval }}[{{ i }}] = <void*>(&__nodepath_{{ arg["name"] }}._gd_data)
 {% elif arg["type_specs"]["is_object"] %}
-## if arg is None, pass NULL to godot
+{## if arg is None, pass NULL to godot #}
 {{ argsval }}[{{ i }}] = <void*>{{ arg["name"] }}._gd_ptr if {{ arg["name"] }} is not None else NULL
 {% elif arg["type"] == "godot_variant" %}
 cdef godot_variant __var_{{ arg["name"] }}
@@ -79,7 +79,7 @@ pyobj_to_godot_variant({{ arg["name"] }}, &__var_{{ arg["name"] }})
 {% elif arg["type_specs"]["is_builtin"] %}
 {{ argsval }}[{{ i }}] = <void*>(&{{ arg["name"] }}._gd_data)
 {% elif arg["type"] == "godot_real" %}
-## ptrcall does not work with single precision floats, so we must convert to a double
+{## ptrcall does not work with single precision floats, so we must convert to a double #}
 cdef double {{ arg["name"] }}_d = <double>{{ arg["name"] }};
 {{ argsval }}[{{ i }}] = &{{ arg["name"] }}_d
 {% else %}
@@ -113,7 +113,7 @@ cdef godot_variant {{ retval }}
 cdef {{ binding_type }} {{ retval }} = {{ binding_type }}.__new__({{ binding_type }})
 {% set retval_as_arg = "&{}._gd_data".format(retval) %}
 {% elif method["return_type"] == "godot_real" %}
-## ptrcall does not work with single precision floats, so we must convert to a double
+{## ptrcall does not work with single precision floats, so we must convert to a double #}
 cdef double {{ retval }}
 {% set retval_as_arg = "&{}".format(retval) %}
 {% else %}

--- a/tools/bindings_templates/method.tmpl.pyx
+++ b/tools/bindings_templates/method.tmpl.pyx
@@ -24,8 +24,8 @@ cdef godot_method_bind *{{ get_method_bind_register_name(cls, method) }} = gdapi
  object {{ arg["name"] }}
 {%- else %}
  {{ arg["type_specs"]["binding_type"] }} {{ arg["name"] }}
-{%- if not arg["type_specs"]["is_base_type"] %}
-  not None
+{%- if not arg["type_specs"]["is_base_type"] and not (arg["has_default_value"] and arg["default_value"] == "None") %}
+  not None ## if default value is NULL, none should be allowed
 {%- endif %}
 {%- endif %}
 {%- if arg["has_default_value"] %}
@@ -70,13 +70,18 @@ cdef GDString __gdstr_{{ arg["name"] }} = ensure_is_gdstring({{ arg["name"] }})
 cdef NodePath __nodepath_{{ arg["name"] }} = ensure_is_nodepath({{ arg["name"] }})
 {{ argsval }}[{{ i }}] = <void*>(&__nodepath_{{ arg["name"] }}._gd_data)
 {% elif arg["type_specs"]["is_object"] %}
-{{ argsval }}[{{ i }}] = <void*>{{ arg["name"] }}._gd_ptr
+## if arg is None, pass NULL to godot
+{{ argsval }}[{{ i }}] = <void*>{{ arg["name"] }}._gd_ptr if {{ arg["name"] }} is not None else NULL
 {% elif arg["type"] == "godot_variant" %}
 cdef godot_variant __var_{{ arg["name"] }}
 pyobj_to_godot_variant({{ arg["name"] }}, &__var_{{ arg["name"] }})
 {{ argsval }}[{{ i }}] = <void*>(&__var_{{ arg["name"] }})
 {% elif arg["type_specs"]["is_builtin"] %}
 {{ argsval }}[{{ i }}] = <void*>(&{{ arg["name"] }}._gd_data)
+{% elif arg["type"] == "godot_real" %}
+## ptrcall does not work with single precision floats, so we must convert to a double
+cdef double {{ arg["name"] }}_d = <double>{{ arg["name"] }};
+{{ argsval }}[{{ i }}] = &{{ arg["name"] }}_d
 {% else %}
 {{ argsval }}[{{ i }}] = &{{ arg["name"] }}
 {% endif %}
@@ -107,6 +112,10 @@ cdef godot_variant {{ retval }}
 {% set binding_type =  method["return_type_specs"]["binding_type"] %}
 cdef {{ binding_type }} {{ retval }} = {{ binding_type }}.__new__({{ binding_type }})
 {% set retval_as_arg = "&{}._gd_data".format(retval) %}
+{% elif method["return_type"] == "godot_real" %}
+## ptrcall does not work with single precision floats, so we must convert to a double
+cdef double {{ retval }}
+{% set retval_as_arg = "&{}".format(retval) %}
 {% else %}
 cdef {{ method["return_type"] }} {{ retval }}
 {% set retval_as_arg = "&{}".format(retval) %}

--- a/tools/bindings_templates/method.tmpl.pyx
+++ b/tools/bindings_templates/method.tmpl.pyx
@@ -111,13 +111,16 @@ cdef {{ binding_type }} {{ retval }} = {{ binding_type }}.__new__({{ binding_typ
 cdef {{ method["return_type"] }} {{ retval }}
 {% set retval_as_arg = "&{}".format(retval) %}
 {% endif %}
+
 global {{ get_method_bind_register_name(cls, method) }}
 if {{ get_method_bind_register_name(cls, method) }} == NULL:
     # Method is sometimes NULL because it is not loaded/available at import time (when godot_method_bind_get_method gets called the first time)
     # So we must try to get it again to make sure it actually is not implemented, or was just not available previously.
     {{ get_method_bind_register_name(cls, method) }} = gdapi10.godot_method_bind_get_method("{{ cls['bind_register_name'] }}", "{{ method['name'] }}")
-    if {{ get_method_bind_register_name(cls, method) }} == NULL:
-        raise NotImplementedError
+
+if {{ get_method_bind_register_name(cls, method) }} == NULL:
+    raise NotImplementedError("Method not available ({{ cls["name"] }}.{{ method["name"] }})")
+
 gdapi10.godot_method_bind_ptrcall(
     {{ get_method_bind_register_name(cls, method) }},
     self._gd_ptr,


### PR DESCRIPTION
This pull request fixes 2 problems with method calls:

1) All base types were `not None`, and we should allow null values for methods which have a base type with default argument null (see `SurfaceTool.commit ( ArrayMesh existing=null, int flags=97280 )`)
2) `godot_method_bind_ptrcall` does not work with floats. Since godot_real is defined as a float, all godot_reals must be converted to doubles before ptrcall, otherwise the value gets completely mangled. (See: https://discordapp.com/channels/212250894228652034/342047011778068481/696177360747233371 and https://discordapp.com/channels/212250894228652034/342047011778068481/696431299115876462)
I thought of using double instead of godot_real everywhere, but that may break a lot of stuff. @touilleMan let me know what you think.

NOTE: this branch is forked from ms-fix-missing-constructor, which needs to be merged first. see #160 