### PR TITLE
Enable GIL when calling pythonscript api entrypoints

### DIFF
--- a/pythonscript/_godot.pyx
+++ b/pythonscript/_godot.pyx
@@ -34,7 +34,7 @@ def _setup_config_entry(name, default_value):
     return ProjectSettings.get_setting(gdname)
 
 
-cdef api godot_pluginscript_language_data *pythonscript_init():
+cdef api godot_pluginscript_language_data *pythonscript_init() with gil:
     # Pass argv arguments
     sys.argv = ["godot"] + [str(x) for x in OS.get_cmdline_args()]
 
@@ -64,5 +64,5 @@ cdef api godot_pluginscript_language_data *pythonscript_init():
     return NULL
 
 
-cdef api void pythonscript_finish(godot_pluginscript_language_data *data):
+cdef api void pythonscript_finish(godot_pluginscript_language_data *data) with gil:
     return

--- a/pythonscript/_godot_editor.pxi
+++ b/pythonscript/_godot_editor.pxi
@@ -25,7 +25,7 @@ cdef api godot_string pythonscript_get_template_source_code(
     godot_pluginscript_language_data *p_data,
     const godot_string *p_class_name,
     const godot_string *p_base_class_name
-):
+) with gil:
     cdef str class_name
     if p_class_name == NULL:
         class_name = "MyExportedCls"
@@ -63,7 +63,7 @@ cdef api godot_bool pythonscript_validate(
     godot_string *r_test_error,
     const godot_string *p_path,
     godot_pool_string_array *r_functions
-):
+) with gil:
     pass
 
 
@@ -71,7 +71,7 @@ cdef api int pythonscript_find_function(
     godot_pluginscript_language_data *p_data,
     const godot_string *p_function,
     const godot_string *p_code
-):
+) with gil:
     return 0
 
 
@@ -80,7 +80,7 @@ cdef api godot_string pythonscript_make_function(
     const godot_string *p_class,
     const godot_string *p_name,
     const godot_pool_string_array *p_args
-):
+) with gil:
     cdef str name = godot_string_to_pyobj(p_name)
 
     # TODO: replace this with PoolStringArray binding once implemented
@@ -110,7 +110,7 @@ cdef api godot_error pythonscript_complete_code(
     godot_array *r_options,
     godot_bool *r_force,
     godot_string *r_call_hint
-):
+) with gil:
     return godot_error.GODOT_OK
 
 
@@ -119,7 +119,7 @@ cdef api void pythonscript_auto_indent_code(
     godot_string *p_code,
     int p_from_line,
     int p_to_line
-):
+) with gil:
     # TODO: use black for this job
 #     try:
 #         import autopep8
@@ -145,7 +145,7 @@ cdef api void pythonscript_add_global_constant(
     godot_pluginscript_language_data *p_data,
     const godot_string *p_variable,
     const godot_variant *p_value
-):
+) with gil:
     name = godot_string_to_pyobj(p_variable)
     value = godot_variant_to_pyobj(p_value)
     # Update `godot.globals` module here
@@ -155,7 +155,7 @@ cdef api void pythonscript_add_global_constant(
 
 cdef api godot_string pythonscript_debug_get_error(
     godot_pluginscript_language_data *p_data
-):
+) with gil:
     cdef godot_string ret
     pyobj_to_godot_string("Nothing", &ret)
     return ret
@@ -163,21 +163,21 @@ cdef api godot_string pythonscript_debug_get_error(
 
 cdef api int pythonscript_debug_get_stack_level_count(
     godot_pluginscript_language_data *p_data
-):
+) with gil:
     return 1
 
 
 cdef api int pythonscript_debug_get_stack_level_line(
     godot_pluginscript_language_data *p_data,
     int p_level
-):
+) with gil:
     return 1
 
 
 cdef api godot_string pythonscript_debug_get_stack_level_function(
     godot_pluginscript_language_data *p_data,
     int p_level
-):
+) with gil:
     cdef godot_string ret
     pyobj_to_godot_string("Nothing", &ret)
     return ret
@@ -186,7 +186,7 @@ cdef api godot_string pythonscript_debug_get_stack_level_function(
 cdef api godot_string pythonscript_debug_get_stack_level_source(
     godot_pluginscript_language_data *p_data,
     int p_level
-):
+) with gil:
     cdef godot_string ret
     pyobj_to_godot_string("Nothing", &ret)
     return ret
@@ -199,7 +199,7 @@ cdef api void pythonscript_debug_get_stack_level_locals(
     godot_array *p_values,
     int p_max_subitems,
     int p_max_depth
-):
+) with gil:
     pass
 
 
@@ -210,7 +210,7 @@ cdef api void pythonscript_debug_get_stack_level_members(
     godot_array *p_values,
     int p_max_subitems,
     int p_max_depth
-):
+) with gil:
     pass
 
 
@@ -220,7 +220,7 @@ cdef api void pythonscript_debug_get_globals(
     godot_array *p_values,
     int p_max_subitems,
     int p_max_depth
-):
+) with gil:
     pass
 
 
@@ -230,7 +230,7 @@ cdef api godot_string pythonscript_debug_parse_stack_level_expression(
     const godot_string *p_expression,
     int p_max_subitems,
     int p_max_depth
-):
+) with gil:
     cdef godot_string ret
     pyobj_to_godot_string("Nothing", &ret)
     return ret
@@ -239,12 +239,12 @@ cdef api godot_string pythonscript_debug_parse_stack_level_expression(
 cdef api void pythonscript_get_public_functions(
     godot_pluginscript_language_data *p_data,
     godot_array *r_functions
-):
+) with gil:
     pass
 
 
 cdef api void pythonscript_get_public_constants(
     godot_pluginscript_language_data *p_data,
     godot_dictionary *r_constants
-):
+) with gil:
     pass

--- a/pythonscript/_godot_instance.pxi
+++ b/pythonscript/_godot_instance.pxi
@@ -29,7 +29,7 @@ from godot._hazmat.conversion cimport (
 cdef api godot_pluginscript_instance_data* pythonscript_instance_init(
     godot_pluginscript_script_data *p_data,
     godot_object *p_owner
-):
+) with gil:
     cdef object instance = (<object>p_data)()
     (<Object>instance)._gd_ptr = p_owner
     Py_INCREF(instance)
@@ -38,7 +38,7 @@ cdef api godot_pluginscript_instance_data* pythonscript_instance_init(
 
 cdef api void pythonscript_instance_finish(
     godot_pluginscript_instance_data *p_data
-):
+) with gil:
     Py_DECREF(<object>p_data)
 
 
@@ -46,7 +46,7 @@ cdef api godot_bool pythonscript_instance_set_prop(
     godot_pluginscript_instance_data *p_data,
     const godot_string *p_name,
     const godot_variant *p_value
-):
+) with gil:
     cdef object instance = <object>p_data
     try:
         setattr(instance, godot_string_to_pyobj(p_name), godot_variant_to_pyobj(p_value))
@@ -60,7 +60,7 @@ cdef api godot_bool pythonscript_instance_get_prop(
     godot_pluginscript_instance_data *p_data,
     const godot_string *p_name,
     godot_variant *r_ret
-):
+) with gil:
     cdef object instance = <object>p_data
     cdef object ret
     try:
@@ -78,7 +78,7 @@ cdef api godot_variant pythonscript_instance_call_method(
     const godot_variant **p_args,
     int p_argcount,
     godot_variant_call_error *r_error
-):
+) with gil:
     cdef godot_variant var_ret
     cdef object instance = <object>p_data
     # TODO: optimize this by caching godot_string_name -> method lookup
@@ -123,7 +123,7 @@ cdef api godot_variant pythonscript_instance_call_method(
 cdef api void pythonscript_instance_notification(
     godot_pluginscript_instance_data *p_data,
     int p_notification
-):
+) with gil:
     cdef object instance = <object>p_data
     # Godot's notification should call all parent `_notification`
     # methods (better not use `super()._notification` in those methods...)
@@ -140,11 +140,11 @@ cdef api void pythonscript_instance_notification(
 
 # cdef api void pythonscript_instance_refcount_incremented(
 #     godot_pluginscript_instance_data *p_data
-# ):
+# ) with gil:
 #     pass
 
 
 # cdef api bool pythonscript_instance_refcount_decremented(
 #     godot_pluginscript_instance_data *p_data
-# ):
+# ) with gil:
 #     pass

--- a/pythonscript/_godot_profiling.pxi
+++ b/pythonscript/_godot_profiling.pxi
@@ -135,7 +135,7 @@ cdef object profiler = None
 
 cdef api void pythonscript_profiling_start(
     godot_pluginscript_language_data *p_data
-):
+) with gil:
     global profiler
     profiler = Profiler()
     sys.setprofile(profiler.get_profilefunc())
@@ -143,7 +143,7 @@ cdef api void pythonscript_profiling_start(
 
 cdef api void pythonscript_profiling_stop(
     godot_pluginscript_language_data *p_data
-):
+) with gil:
     global profiler
     profiler = None
     sys.setprofile(None)
@@ -153,7 +153,7 @@ cdef api int pythonscript_profiling_get_accumulated_data(
     godot_pluginscript_language_data *p_data,
     godot_pluginscript_profiling_data *r_info,
     int p_info_max
-):
+) with gil:
     # Sort function to make sure we can display the most consuming ones
     sorted_and_limited = sorted(
         profiler.per_meth_profiling.items(), key=lambda x: -x[1].self_time
@@ -173,7 +173,7 @@ cdef api int pythonscript_profiling_get_frame_data(
     godot_pluginscript_language_data *p_data,
     godot_pluginscript_profiling_data *r_info,
     int p_info_max
-):
+) with gil:
     # Sort function to make sure we can display the most consuming ones
     sorted_and_limited = sorted(
         profiler.per_meth_profiling.items(), key=lambda x: -x[1].last_frame_self_time
@@ -191,6 +191,6 @@ cdef api int pythonscript_profiling_get_frame_data(
 
 cdef api void pythonscript_profiling_frame(
     godot_pluginscript_language_data *p_data
-):
+) with gil:
     if profiler is not None:
         profiler.next_frame()

--- a/pythonscript/_godot_script.pxi
+++ b/pythonscript/_godot_script.pxi
@@ -141,7 +141,7 @@ cdef api godot_pluginscript_script_manifest pythonscript_script_init(
     const godot_string *p_path,
     const godot_string *p_source,
     godot_error *r_error
-):
+) with gil:
     # Godot class&singleton are not all available at Pythonscript bootstrap.
     # Hence we wait until the Pythonscript start being actually used (i.e. until
     # the first Python script is loaded) before initializing the bindings.
@@ -193,5 +193,5 @@ cdef api godot_pluginscript_script_manifest pythonscript_script_init(
 
 cdef api void pythonscript_script_finish(
     godot_pluginscript_script_data *p_data
-):
+) with gil:
     destroy_exposed_class(<object>p_data)


### PR DESCRIPTION
This typically fix crashes with the Godot editor when it tries to load resources in parallel