### PR TITLE
Redirect stdout and stderr to Godot

### DIFF
--- a/pythonscript/SConscript
+++ b/pythonscript/SConscript
@@ -44,6 +44,7 @@ SConscript([
     '_godot_instance.pxi',
     '_godot_profiling.pxi',
     '_godot_script.pxi',
+    '_godot_io.pxi',
 ])
 env.Install(
     "$DIST_SITE_PACKAGES",

--- a/pythonscript/_godot.pyx
+++ b/pythonscript/_godot.pyx
@@ -9,6 +9,7 @@ include "_godot_editor.pxi"
 include "_godot_profiling.pxi"
 include "_godot_script.pxi"
 include "_godot_instance.pxi"
+include "_godot_io.pxi"
 
 from godot._hazmat.gdnative_api_struct cimport (
     godot_gdnative_init_options,
@@ -34,7 +35,7 @@ def _setup_config_entry(name, default_value):
     return ProjectSettings.get_setting(gdname)
 
 
-cdef api godot_pluginscript_language_data *pythonscript_init():
+cdef api godot_pluginscript_language_data *pythonscript_init() with gil:
     # Pass argv arguments
     sys.argv = ["godot"] + [str(x) for x in OS.get_cmdline_args()]
 
@@ -46,8 +47,8 @@ cdef api godot_pluginscript_language_data *pythonscript_init():
 
     # TODO
     # Redirect stdout/stderr to have it in the Godot editor console
-    # if _setup_config_entry("python_script/io_streams_capture", True):
-    #     enable_capture_io_streams()
+    #if _setup_config_entry("python_script/io_streams_capture", True):
+    GodotIO.enable_capture_io_streams()
 
     # Enable verbose output from pythonscript framework
     if _setup_config_entry("python_script/verbose", False):

--- a/pythonscript/_godot.pyx
+++ b/pythonscript/_godot.pyx
@@ -47,8 +47,8 @@ cdef api godot_pluginscript_language_data *pythonscript_init() with gil:
 
     # TODO
     # Redirect stdout/stderr to have it in the Godot editor console
-    #if _setup_config_entry("python_script/io_streams_capture", True):
-    GodotIO.enable_capture_io_streams()
+    if _setup_config_entry("python_script/io_streams_capture", True):
+        GodotIO.enable_capture_io_streams()
 
     # Enable verbose output from pythonscript framework
     if _setup_config_entry("python_script/verbose", False):

--- a/pythonscript/_godot_io.pxi
+++ b/pythonscript/_godot_io.pxi
@@ -67,7 +67,7 @@ class GodotIO:
         # we are printing an error message, so we must avoid other errors at all costs,
         # otherwise the user may never see the error message printed, making debugging a living hell
         try:
-            if lineno is not None and filename is not None and name is not None:
+            if lineno is None and filename is None and name is None:
                 # don't try to get exception info if user provided the details.
                 exc_info = sys.exc_info()
                 tb = exc_info[2]
@@ -78,14 +78,14 @@ class GodotIO:
                         filename = tblist[-1].filename
                         name = tblist[-1].name
         except:
-            sys.__stderr__.write('Additional errors occured while printing:\n' + traceback.format_exc() + '\n')
+            sys.__stderr__.write("Additional errors occured while printing:\n" + traceback.format_exc() + "\n")
         
         # default values in case we couldn't get exception info and user have not provided those
+        pystr = pystr or ""
         lineno = lineno or 0
-        filename = filename or '<UNKNOWN>'
-        name = name or '<UNKNOWN>'
+        filename = filename or "UNKNOWN"
+        name = name or "UNKNOWN"
         
-        # TODO: how to handle different encodings?
         pystr = pystr.encode('utf-8')
         name = name.encode('utf-8')
         filename = filename.encode('utf-8')
@@ -94,12 +94,12 @@ class GodotIO:
         cdef char * c_name = name
         cdef char * c_filename = filename
         cdef int c_lineno = <int>lineno
-        
+
         with nogil:
             gdapi10.godot_print_error(c_msg, c_name, c_filename, c_lineno)
     
     @staticmethod
-    def print_override(*objects, sep=' ', end='\n', file=sys.stdout, flush=False):
+    def print_override(*objects, sep=" ", end="\n", file=sys.stdout, flush=False):
         """
             We need to override the builtin print function to avoid multiple calls to stderr.write.
             e.g:
@@ -108,7 +108,6 @@ class GodotIO:
                 Since we are using godot_print_error, that would cause a very weird print to the console,
                 so overriding print and making sure a single call to write is issued solves the problem.
         """
-
         if file == GodotIO.get_godot_stderr_io():
             msg = str(sep).join([str(obj) for obj in objects]) + str(end)
             GodotIO.godot_print_error_pystr(msg)
@@ -151,13 +150,13 @@ class GodotIO:
 
     
     @staticmethod
-    def get_godot_stdout_io(cls):
+    def get_godot_stdout_io():
         if not GodotIO._godot_stderr_io:
-            GodotIO._godot_stderr_io = GodotIOStream(GodotIO.godot_print_error_pystr)
+            GodotIO._godot_stderr_io = GodotIOStream(GodotIO.godot_print_pystr)
         return GodotIO._godot_stderr_io
 
     @staticmethod
-    def get_godot_stderr_io(cls):
+    def get_godot_stderr_io():
         if not GodotIO._godot_stderr_io:
             GodotIO._godot_stderr_io = GodotIOStream(GodotIO.godot_print_error_pystr)
         return GodotIO._godot_stderr_io

--- a/pythonscript/_godot_io.pxi
+++ b/pythonscript/_godot_io.pxi
@@ -1,0 +1,146 @@
+from io import RawIOBase
+from godot._hazmat.conversion cimport (
+    godot_string_to_pyobj,
+    pyobj_to_godot_string,
+    godot_variant_to_pyobj,
+)
+from godot._hazmat.gdnative_api_struct cimport (
+    godot_string,
+    godot_string_name,
+    godot_bool,
+    godot_array,
+    godot_pool_string_array,
+    godot_object,
+    godot_variant,
+    godot_variant_call_error,
+    godot_method_rpc_mode,
+    godot_pluginscript_script_data,
+    godot_pluginscript_instance_data,
+    godot_variant_call_error_error,
+    godot_variant_type
+)
+
+class GodotIOStream(RawIOBase):
+
+    def __init__(self, godot_print_func):
+        self.buffer = ""
+        self.godot_print_func = godot_print_func
+
+    def write(self, b):
+        self.buffer += b
+        if "\n" in self.buffer:
+            *to_print, self.buffer = self.buffer.split("\n")
+            self.godot_print_func("\n".join(to_print))
+
+    def flush(self):
+        if self.buffer:
+            self.godot_print_func(self.buffer)
+            self.buffer = ""
+
+class GodotIO:
+
+    _godot_stdout_io = None
+    _godot_stderr_io = None
+    _builtin_print = None
+    _traceback_print_exception = None
+
+    @staticmethod
+    def godot_print_pystr(pystr):
+        """
+            Receives a python string (pystr), convert to a godot string, and print using the godot print function.
+        """
+        cdef godot_string gdstr
+        pyobj_to_godot_string(pystr, &gdstr)
+        with nogil:
+            gdapi10.godot_print(&gdstr)
+            gdapi10.godot_string_destroy(&gdstr)
+    
+    @staticmethod
+    def godot_print_error_pystr(pystr):
+        """
+            Receives a python string (pystr), convert to char*, and print using the godot_print_error function.
+            Also tries to get exception information such as, file name, line numer, method name, etc
+            and pass that along to godot_print_error
+        """
+        import traceback
+        sys.__stdout__.write('HERE SYS INFO\n')
+        lineno = 0
+        filename = '<UNKNOWN>'
+        name = '<UNKNOWN>'
+
+        # we are printing an error message, so we must avoid other errors at all costs,
+        # otherwise the user may never see the error message printed, making debugging a living hell
+        try:
+            exc_info = sys.exc_info()
+            tb = exc_info[2]
+            if tb:
+                tblist = traceback.extract_tb(tb)
+                if len(tblist) > 0:
+                    lineno = tblist[-1].lineno
+                    filename = tblist[-1].filename
+                    name = tblist[-1].name
+        except:
+            pass
+        # TODO: how to handle different encodings?
+        pystr = pystr.encode('utf-8')
+        name = name.encode('utf-8')
+        filename = filename.encode('utf-8')
+        cdef char * c_msg = pystr
+        cdef char * c_name = name
+        cdef char * c_filename = filename
+        cdef int c_lineno = <int>lineno
+        with nogil:
+            gdapi10.godot_print_error(c_msg, c_name, c_filename, c_lineno)
+    
+    @staticmethod
+    def print_override(*objects, sep=' ', end='\n', file=sys.stdout, flush=False):
+        if file == GodotIO.get_godot_stderr_io():
+            msg = str(sep).join([str(obj) for obj in objects]) + str(end)
+            GodotIO.godot_print_error_pystr(msg)
+        else:
+            GodotIO._builtin_print(*objects, sep=sep, end=end, file=file, flush=flush)
+    
+    @staticmethod
+    def print_exception_override(etype, value, tb, limit=None, file=None, chain=True):
+        # We override traceback.print_exception to avoid multiple calls to godot_print_error on newlines,
+        # making the traceback look weird
+        from traceback import TracebackException
+        if file is None:
+            file = sys.stderr
+        trace = "\n"
+        for line in TracebackException(type(value), value, tb, limit=limit).format(chain=chain):
+            trace += str(line)
+        GodotIO.godot_print_error_pystr(trace)
+    
+    @staticmethod
+    def enable_capture_io_streams():
+        import sys
+        import builtins
+        import traceback
+        # flush existing buffer
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # make stdout and stderr the custom iostream defined above
+        sys.stdout = GodotIO.get_godot_stdout_io()
+        sys.stderr = GodotIO.get_godot_stderr_io()
+
+        # override python print function
+        GodotIO._builtin_print = builtins.print
+        builtins.print = GodotIO.print_override
+
+        # override traceback.print_exception
+        GodotIO._traceback_print_exception = traceback.print_exception
+        traceback.print_exception = GodotIO.print_exception_override
+
+    
+    @staticmethod
+    def get_godot_stdout_io(cls):
+        if not GodotIO._godot_stderr_io:
+            GodotIO._godot_stderr_io = GodotIOStream(GodotIO.godot_print_error_pystr)
+        return GodotIO._godot_stderr_io
+
+    @staticmethod
+    def get_godot_stderr_io(cls):
+        if not GodotIO._godot_stderr_io:
+            GodotIO._godot_stderr_io = GodotIOStream(GodotIO.godot_print_error_pystr)
+        return GodotIO._godot_stderr_io

--- a/pythonscript/_godot_io.pxi
+++ b/pythonscript/_godot_io.pxi
@@ -85,11 +85,11 @@ class GodotIO:
         lineno = lineno or 0
         filename = filename or "UNKNOWN"
         name = name or "UNKNOWN"
-        
+
         pystr = pystr.encode('utf-8')
         name = name.encode('utf-8')
         filename = filename.encode('utf-8')
-        
+
         cdef char * c_msg = pystr
         cdef char * c_name = name
         cdef char * c_filename = filename


### PR DESCRIPTION
This PR implements a custom IO stream object that replaces sys.stdout and sys.stderr, and passes print calls to godot_print and godot_print_error.
It also override the builtin print function and traceback.print_exception in order to make sure exception tracebacks are printed in a single call to godot_print_error, avoiding weird traceback printing.