### PR TITLE
Fix globals

### DIFF
--- a/pythonscript/_godot_editor.pxi
+++ b/pythonscript/_godot_editor.pxi
@@ -146,6 +146,7 @@ cdef api void pythonscript_add_global_constant(
     const godot_string *p_variable,
     const godot_variant *p_value
 ) with gil:
+    _initialize_bindings()
     name = godot_string_to_pyobj(p_variable)
     value = godot_variant_to_pyobj(p_value)
     # Update `godot.globals` module here

--- a/pythonscript/_godot_editor.pxi
+++ b/pythonscript/_godot_editor.pxi
@@ -146,9 +146,12 @@ cdef api void pythonscript_add_global_constant(
     const godot_string *p_variable,
     const godot_variant *p_value
 ) with gil:
-    _initialize_bindings()
     name = godot_string_to_pyobj(p_variable)
     value = godot_variant_to_pyobj(p_value)
+    # Godot class&singleton bindings are supposed to be initialized on first
+    # python script load. However adding a global constant can occur prior to
+    # that so we must force the init here before using `godot.globals`.
+    _initialize_bindings()
     # Update `godot.globals` module here
     import godot
     godot.globals.__dict__[name] = value


### PR DESCRIPTION
Fixes #194 

Problem:
Creating a global singleton causes `_godot_editor.pxi##pythonscript_add_global_constant` to be called before bindings are initialized.
```
(lldb) p __pyx_v_5godot_8bindings___methbind__Object__get_class
(godot_method_bind *) $0 = 0x0000000000000000
```

Solution:
call `initialize_bindings` in `pythonscript_add_global_constant`