### PR TITLE
Make godot-python importable even if we are not in the godot engine.

### DIFF
--- a/pythonscript/godot/array.pyx
+++ b/pythonscript/godot/array.pyx
@@ -29,10 +29,14 @@ cdef class Array:
         def __init__(self, iterable=None):
             return
 
-    def __dealloc__(self):
-        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-        # hand otherwise we will get a segfault here
-        gdapi10.godot_array_destroy(&self._gd_data)
+    if gdapi10 != NULL:
+        def __dealloc__(self):
+            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+            # hand otherwise we will get a segfault here
+            gdapi10.godot_array_destroy(&self._gd_data)
+    else:
+        def __dealloc__(self):
+            return
 
     @staticmethod
     cdef inline Array new():

--- a/pythonscript/godot/array.pyx
+++ b/pythonscript/godot/array.pyx
@@ -27,14 +27,12 @@ cdef class Array:
             for x in iterable:
                 self.append(x)
 
-    if gdapi10 != NULL:
-        def __dealloc__(self):
-            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-            # hand otherwise we will get a segfault here
-            gdapi10.godot_array_destroy(&self._gd_data)
-    else:
-        def __dealloc__(self):
+    def __dealloc__(self):
+        if gdapi10 == NULL:
             return
+        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+        # hand otherwise we will get a segfault here
+        gdapi10.godot_array_destroy(&self._gd_data)
 
     @staticmethod
     cdef inline Array new():

--- a/pythonscript/godot/array.pyx
+++ b/pythonscript/godot/array.pyx
@@ -14,20 +14,18 @@ from godot._hazmat.conversion cimport godot_variant_to_pyobj, pyobj_to_godot_var
 @cython.final
 cdef class Array:
 
-    if gdapi10 != NULL:
-        def __init__(self, iterable=None):
-            if not iterable:
-                gdapi10.godot_array_new(&self._gd_data)
-            elif isinstance(iterable, Array):
-                self._gd_data = gdapi11.godot_array_duplicate(&(<Array>iterable)._gd_data, False)
-            # TODO: handle Pool*Array
-            else:
-                gdapi10.godot_array_new(&self._gd_data)
-                for x in iterable:
-                    self.append(x)
-    else:
-        def __init__(self, iterable=None):
+    def __init__(self, iterable=None):
+        if gdapi10 == NULL:
             return
+        if not iterable:
+            gdapi10.godot_array_new(&self._gd_data)
+        elif isinstance(iterable, Array):
+            self._gd_data = gdapi11.godot_array_duplicate(&(<Array>iterable)._gd_data, False)
+        # TODO: handle Pool*Array
+        else:
+            gdapi10.godot_array_new(&self._gd_data)
+            for x in iterable:
+                self.append(x)
 
     if gdapi10 != NULL:
         def __dealloc__(self):

--- a/pythonscript/godot/array.pyx
+++ b/pythonscript/godot/array.pyx
@@ -14,16 +14,20 @@ from godot._hazmat.conversion cimport godot_variant_to_pyobj, pyobj_to_godot_var
 @cython.final
 cdef class Array:
 
-    def __init__(self, iterable=None):
-        if not iterable:
-            gdapi10.godot_array_new(&self._gd_data)
-        elif isinstance(iterable, Array):
-            self._gd_data = gdapi11.godot_array_duplicate(&(<Array>iterable)._gd_data, False)
-        # TODO: handle Pool*Array
-        else:
-            gdapi10.godot_array_new(&self._gd_data)
-            for x in iterable:
-                self.append(x)
+    if gdapi10 != NULL:
+        def __init__(self, iterable=None):
+            if not iterable:
+                gdapi10.godot_array_new(&self._gd_data)
+            elif isinstance(iterable, Array):
+                self._gd_data = gdapi11.godot_array_duplicate(&(<Array>iterable)._gd_data, False)
+            # TODO: handle Pool*Array
+            else:
+                gdapi10.godot_array_new(&self._gd_data)
+                for x in iterable:
+                    self.append(x)
+    else:
+        def __init__(self, iterable=None):
+            return
 
     def __dealloc__(self):
         # /!\ if `__init__` is skipped, `_gd_data` must be initialized by

--- a/site_scons/site_tools/cython.py
+++ b/site_scons/site_tools/cython.py
@@ -26,7 +26,7 @@ def _cython_to_c_emitter(target, source, env):
 
 
 CythonToCBuilder = Builder(
-    action="cython $CYTHON_FLAGS $SOURCE -o $TARGET",
+    action="cython $CYTHON_FLAGS $SOURCE -o $TARGET --directive embedsignature=True",
     suffix=".c",
     src_suffix=".pyx",
     emitter=_cython_to_c_emitter,

--- a/tests/helloworld/project.godot
+++ b/tests/helloworld/project.godot
@@ -6,7 +6,12 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=3
+config_version=4
+
+_global_script_classes=[  ]
+_global_script_class_icons={
+
+}
 
 [application]
 

--- a/tools/bindings_templates/bindings.tmpl.pyx
+++ b/tools/bindings_templates/bindings.tmpl.pyx
@@ -31,17 +31,23 @@ __ERR_MSG_BINDING_NOT_AVAILABLE = "No Godot binding available"
 # The remaining loading will be achieved when loading the first python script
 # (where at this point Godot should have finished it initialization).
 
+if gdapi10 == NULL:
+    print("ERROR: GDNative API is not available!")
+
 {% set early_needed_bindings = ["_OS", "_ProjectSettings"] %}
 cdef godot_object *_ptr
 {% for cls in classes %}
 {% if cls["name"] in early_needed_bindings %}
 {{ render_class_gdapi_ptrs_init(cls) }}
 {% if cls["singleton"] %}
-_ptr = gdapi10.godot_global_get_singleton("{{ cls['singleton_name'] }}")
-if _ptr != NULL:
-    {{ cls['singleton_name'] }} = {{ cls["name"] }}.from_ptr(_ptr)
-else:
-    print("ERROR: cannot load singleton `{{ cls['singleton_name'] }}` required for Pythonscript init")
+{{ cls['singleton_name'] }} = None
+if gdapi10:
+    _ptr = gdapi10.godot_global_get_singleton("{{ cls['singleton_name'] }}")
+    if _ptr != NULL:
+        {{ cls['singleton_name'] }} = {{ cls["name"] }}.from_ptr(_ptr)
+    else:
+        print("ERROR: cannot load singleton `{{ cls['singleton_name'] }}` required for Pythonscript init")
+
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -11,7 +11,9 @@ __{{ cls["name"] }}_constructor = gdapi10.godot_get_class_constructor("{{ cls['n
 
 {% for method in cls["methods"] %}
 global {{ get_method_bind_register_name(cls, method) }}
-{{ get_method_bind_register_name(cls, method) }} = gdapi10.godot_method_bind_get_method("{{ cls['bind_register_name'] }}", "{{ method['name'] }}")
+if gdapi10:
+    {{ get_method_bind_register_name(cls, method) }} = gdapi10.godot_method_bind_get_method("{{ cls['bind_register_name'] }}", "{{ method['name'] }}")
+
 {% endfor %}
 
 {% endmacro %}

--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -88,35 +88,33 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
         except TypeError:
             return True
 
-    if gdapi10 != NULL:
-        def __getattr__(self, name):
-            cdef GDString gdname = GDString(name)
-            cdef GDString gdnamefield = GDString("name")
-
-            # If a script is attached to the object, we expose here it methods
-            if not hasattr(type(self), '__exposed_python_class'):
-                if self.has_method(name):
-
-                    def _call(*args):
-                        print(f'CALLING _CALL {name!r} on {self!r}')
-                        return {{ cls["name"] }}.callv(self, gdname, Array(args))
-
-                    return _call
-                    # from functools import partial
-                    # return partial(self.call, gdname)
-
-                elif any(x for x in self.get_property_list() if x[gdnamefield] == gdname):
-                    # TODO: Godot currently lacks a `has_property` method
-                    return self.get(gdname)
-
+    def __getattr__(self, name):
+        if gdapi10 == NULL:
             raise AttributeError(
                 f"`{type(self).__name__}` object has no attribute `{name}`"
             )
-    else:
-        def __getattr__(self, name):
-            raise AttributeError(
-                f"`{type(self).__name__}` object has no attribute `{name}`"
-            )
+        cdef GDString gdname = GDString(name)
+        cdef GDString gdnamefield = GDString("name")
+
+        # If a script is attached to the object, we expose here it methods
+        if not hasattr(type(self), '__exposed_python_class'):
+            if self.has_method(name):
+
+                def _call(*args):
+                    print(f'CALLING _CALL {name!r} on {self!r}')
+                    return {{ cls["name"] }}.callv(self, gdname, Array(args))
+
+                return _call
+                # from functools import partial
+                # return partial(self.call, gdname)
+
+            elif any(x for x in self.get_property_list() if x[gdnamefield] == gdname):
+                # TODO: Godot currently lacks a `has_property` method
+                return self.get(gdname)
+
+        raise AttributeError(
+            f"`{type(self).__name__}` object has no attribute `{name}`"
+        )
 
     def __setattr__(self, name, value):
         cdef GDString gdname = GDString(name)

--- a/tools/bindings_templates/class.tmpl.pyx
+++ b/tools/bindings_templates/class.tmpl.pyx
@@ -88,29 +88,35 @@ cdef class {{ cls["name"] }}({{ cls["base_class"] }}):
         except TypeError:
             return True
 
-    def __getattr__(self, name):
-        cdef GDString gdname = GDString(name)
-        cdef GDString gdnamefield = GDString("name")
+    if gdapi10 != NULL:
+        def __getattr__(self, name):
+            cdef GDString gdname = GDString(name)
+            cdef GDString gdnamefield = GDString("name")
 
-        # If a script is attached to the object, we expose here it methods
-        if not hasattr(type(self), '__exposed_python_class'):
-            if self.has_method(name):
+            # If a script is attached to the object, we expose here it methods
+            if not hasattr(type(self), '__exposed_python_class'):
+                if self.has_method(name):
 
-                def _call(*args):
-                    print(f'CALLING _CALL {name!r} on {self!r}')
-                    return {{ cls["name"] }}.callv(self, gdname, Array(args))
+                    def _call(*args):
+                        print(f'CALLING _CALL {name!r} on {self!r}')
+                        return {{ cls["name"] }}.callv(self, gdname, Array(args))
 
-                return _call
-                # from functools import partial
-                # return partial(self.call, gdname)
+                    return _call
+                    # from functools import partial
+                    # return partial(self.call, gdname)
 
-            elif any(x for x in self.get_property_list() if x[gdnamefield] == gdname):
-                # TODO: Godot currently lacks a `has_property` method
-                return self.get(gdname)
+                elif any(x for x in self.get_property_list() if x[gdnamefield] == gdname):
+                    # TODO: Godot currently lacks a `has_property` method
+                    return self.get(gdname)
 
-        raise AttributeError(
-            f"`{type(self).__name__}` object has no attribute `{name}`"
-        )
+            raise AttributeError(
+                f"`{type(self).__name__}` object has no attribute `{name}`"
+            )
+    else:
+        def __getattr__(self, name):
+            raise AttributeError(
+                f"`{type(self).__name__}` object has no attribute `{name}`"
+            )
 
     def __setattr__(self, name, value):
         cdef GDString gdname = GDString(name)

--- a/tools/builtins_templates/aabb.tmpl.pxi
+++ b/tools/builtins_templates/aabb.tmpl.pxi
@@ -44,12 +44,10 @@ cdef class AABB:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
-            gdapi10.godot_aabb_new(&self._gd_data, &pos._gd_data, &size._gd_data)
-    else:
-        def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
+    def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_aabb_new(&self._gd_data, &pos._gd_data, &size._gd_data)
 
     def __repr__(self):
         return f"<AABB({self.as_string()})>"

--- a/tools/builtins_templates/aabb.tmpl.pxi
+++ b/tools/builtins_templates/aabb.tmpl.pxi
@@ -43,8 +43,13 @@ cdef class AABB:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
-        gdapi10.godot_aabb_new(&self._gd_data, &pos._gd_data, &size._gd_data)
+
+    if gdapi10 != NULL:
+        def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
+            gdapi10.godot_aabb_new(&self._gd_data, &pos._gd_data, &size._gd_data)
+    else:
+        def __init__(self, Vector3 pos not None=Vector3(), Vector3 size not None=Vector3()):
+            return
 
     def __repr__(self):
         return f"<AABB({self.as_string()})>"

--- a/tools/builtins_templates/basis.tmpl.pxi
+++ b/tools/builtins_templates/basis.tmpl.pxi
@@ -63,8 +63,12 @@ cdef class Basis:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
-        gdapi10.godot_basis_new_with_rows(&self._gd_data, &(<Vector3>x)._gd_data, &(<Vector3>y)._gd_data, &(<Vector3>z)._gd_data)
+    if gdapi10 != NULL:
+        def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
+            gdapi10.godot_basis_new_with_rows(&self._gd_data, &(<Vector3>x)._gd_data, &(<Vector3>y)._gd_data, &(<Vector3>z)._gd_data)
+    else:
+        def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
+            return
 
     @staticmethod
     def from_euler(from_):

--- a/tools/builtins_templates/basis.tmpl.pxi
+++ b/tools/builtins_templates/basis.tmpl.pxi
@@ -63,12 +63,10 @@ cdef class Basis:
 {% endblock %}
 
 {% block python_defs %}
-    if gdapi10 != NULL:
-        def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
-            gdapi10.godot_basis_new_with_rows(&self._gd_data, &(<Vector3>x)._gd_data, &(<Vector3>y)._gd_data, &(<Vector3>z)._gd_data)
-    else:
-        def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
+    def __init__(self, Vector3 x not None=Vector3.RIGHT, Vector3 y not None=Vector3.UP, Vector3 z not None=Vector3.BACK):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_basis_new_with_rows(&self._gd_data, &(<Vector3>x)._gd_data, &(<Vector3>y)._gd_data, &(<Vector3>z)._gd_data)
 
     @staticmethod
     def from_euler(from_):

--- a/tools/builtins_templates/builtins.tmpl.pxd
+++ b/tools/builtins_templates/builtins.tmpl.pxd
@@ -3,6 +3,7 @@
 
 cimport cython
 
+from godot._hazmat.gdapi cimport pythonscript_gdapi10 as gdapi10
 from godot._hazmat.gdnative_api_struct cimport *
 from godot.array cimport Array
 from godot.pool_arrays cimport (

--- a/tools/builtins_templates/color.tmpl.pxi
+++ b/tools/builtins_templates/color.tmpl.pxi
@@ -49,11 +49,17 @@ cdef class Color:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
-        if a is None:
-            gdapi10.godot_color_new_rgb(&self._gd_data, r, g, b)
-        else:
-            gdapi10.godot_color_new_rgba(&self._gd_data, r, g, b, a)
+    
+    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
+    if gdapi10 != NULL:
+        def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
+            if a is None:
+                gdapi10.godot_color_new_rgb(&self._gd_data, r, g, b)
+            else:
+                gdapi10.godot_color_new_rgba(&self._gd_data, r, g, b, a)
+    else:
+        def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
+            return
 
     def __repr__(self):
         return f"<Color(r={self.r}, g={self.g}, b={self.b}, a={self.a})>"

--- a/tools/builtins_templates/color.tmpl.pxi
+++ b/tools/builtins_templates/color.tmpl.pxi
@@ -50,16 +50,13 @@ cdef class Color:
 
 {% block python_defs %}
     
-    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
-    if gdapi10 != NULL:
-        def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
-            if a is None:
-                gdapi10.godot_color_new_rgb(&self._gd_data, r, g, b)
-            else:
-                gdapi10.godot_color_new_rgba(&self._gd_data, r, g, b, a)
-    else:
-        def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
+    def __init__(self, godot_real r=0, godot_real g=0, godot_real b=0, a=None):
+        if gdapi10 == NULL:
             return
+        if a is None:
+            gdapi10.godot_color_new_rgb(&self._gd_data, r, g, b)
+        else:
+            gdapi10.godot_color_new_rgba(&self._gd_data, r, g, b, a)
 
     def __repr__(self):
         return f"<Color(r={self.r}, g={self.g}, b={self.b}, a={self.a})>"

--- a/tools/builtins_templates/dictionary.tmpl.pxi
+++ b/tools/builtins_templates/dictionary.tmpl.pxi
@@ -62,14 +62,12 @@ cdef class Dictionary:
             except ValueError as exc:
                 raise ValueError("dictionary update sequence element has length 1; 2 is required")
 
-    if gdapi10 != NULL:
-        def __dealloc__(self):
-            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-            # hand otherwise we will get a segfault here
-            gdapi10.godot_dictionary_destroy(&self._gd_data)
-    else:
-        def __dealloc__(self):
+    def __dealloc__(self):
+        if gdapi10 == NULL:
             return
+        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+        # hand otherwise we will get a segfault here
+        gdapi10.godot_dictionary_destroy(&self._gd_data)
 
     def __repr__(self):
         repr_dict = {}

--- a/tools/builtins_templates/dictionary.tmpl.pxi
+++ b/tools/builtins_templates/dictionary.tmpl.pxi
@@ -42,23 +42,27 @@ cdef class Dictionary:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, iterable=None):
-        if not iterable:
-            gdapi10.godot_dictionary_new(&self._gd_data)
-        elif isinstance(iterable, Dictionary):
-            self._gd_data = gdapi12.godot_dictionary_duplicate(&(<Dictionary>iterable)._gd_data, False)
-        # TODO: handle Pool*Array
-        elif isinstance(iterable, dict):
-            gdapi10.godot_dictionary_new(&self._gd_data)
-            for k, v in iterable.items():
-                self[k] = v
-        else:
-            gdapi10.godot_dictionary_new(&self._gd_data)
-            try:
-                for k, v in iterable:
+    if gdapi10 != NULL:
+        def __init__(self, iterable=None):
+            if not iterable:
+                gdapi10.godot_dictionary_new(&self._gd_data)
+            elif isinstance(iterable, Dictionary):
+                self._gd_data = gdapi12.godot_dictionary_duplicate(&(<Dictionary>iterable)._gd_data, False)
+            # TODO: handle Pool*Array
+            elif isinstance(iterable, dict):
+                gdapi10.godot_dictionary_new(&self._gd_data)
+                for k, v in iterable.items():
                     self[k] = v
-            except ValueError as exc:
-                raise ValueError("dictionary update sequence element has length 1; 2 is required")
+            else:
+                gdapi10.godot_dictionary_new(&self._gd_data)
+                try:
+                    for k, v in iterable:
+                        self[k] = v
+                except ValueError as exc:
+                    raise ValueError("dictionary update sequence element has length 1; 2 is required")
+    else:
+        def __init__(self, iterable=None):
+            return
 
     def __dealloc__(self):
         # /!\ if `__init__` is skipped, `_gd_data` must be initialized by

--- a/tools/builtins_templates/dictionary.tmpl.pxi
+++ b/tools/builtins_templates/dictionary.tmpl.pxi
@@ -42,27 +42,25 @@ cdef class Dictionary:
 {% endblock %}
 
 {% block python_defs %}
-    if gdapi10 != NULL:
-        def __init__(self, iterable=None):
-            if not iterable:
-                gdapi10.godot_dictionary_new(&self._gd_data)
-            elif isinstance(iterable, Dictionary):
-                self._gd_data = gdapi12.godot_dictionary_duplicate(&(<Dictionary>iterable)._gd_data, False)
-            # TODO: handle Pool*Array
-            elif isinstance(iterable, dict):
-                gdapi10.godot_dictionary_new(&self._gd_data)
-                for k, v in iterable.items():
-                    self[k] = v
-            else:
-                gdapi10.godot_dictionary_new(&self._gd_data)
-                try:
-                    for k, v in iterable:
-                        self[k] = v
-                except ValueError as exc:
-                    raise ValueError("dictionary update sequence element has length 1; 2 is required")
-    else:
-        def __init__(self, iterable=None):
+    def __init__(self, iterable=None):
+        if gdapi10 == NULL:
             return
+        if not iterable:
+            gdapi10.godot_dictionary_new(&self._gd_data)
+        elif isinstance(iterable, Dictionary):
+            self._gd_data = gdapi12.godot_dictionary_duplicate(&(<Dictionary>iterable)._gd_data, False)
+        # TODO: handle Pool*Array
+        elif isinstance(iterable, dict):
+            gdapi10.godot_dictionary_new(&self._gd_data)
+            for k, v in iterable.items():
+                self[k] = v
+        else:
+            gdapi10.godot_dictionary_new(&self._gd_data)
+            try:
+                for k, v in iterable:
+                    self[k] = v
+            except ValueError as exc:
+                raise ValueError("dictionary update sequence element has length 1; 2 is required")
 
     if gdapi10 != NULL:
         def __dealloc__(self):

--- a/tools/builtins_templates/dictionary.tmpl.pxi
+++ b/tools/builtins_templates/dictionary.tmpl.pxi
@@ -64,10 +64,14 @@ cdef class Dictionary:
         def __init__(self, iterable=None):
             return
 
-    def __dealloc__(self):
-        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-        # hand otherwise we will get a segfault here
-        gdapi10.godot_dictionary_destroy(&self._gd_data)
+    if gdapi10 != NULL:
+        def __dealloc__(self):
+            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+            # hand otherwise we will get a segfault here
+            gdapi10.godot_dictionary_destroy(&self._gd_data)
+    else:
+        def __dealloc__(self):
+            return
 
     def __repr__(self):
         repr_dict = {}

--- a/tools/builtins_templates/gdstring.tmpl.pxi
+++ b/tools/builtins_templates/gdstring.tmpl.pxi
@@ -178,14 +178,12 @@ cdef class GDString:
         else:
             pyobj_to_godot_string(pystr, &self._gd_data)
 
-    if gdapi10 != NULL:
-        def __dealloc__(GDString self):
-            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-            # hand otherwise we will get a segfault here
-            gdapi10.godot_string_destroy(&self._gd_data)
-    else:
-        def __dealloc__(GDString self):
+    def __dealloc__(GDString self):
+        if gdapi10 == NULL:
             return
+        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+        # hand otherwise we will get a segfault here
+        gdapi10.godot_string_destroy(&self._gd_data)
 
     def __repr__(GDString self):
         return f"<GDString({str(self)!r})>"

--- a/tools/builtins_templates/gdstring.tmpl.pxi
+++ b/tools/builtins_templates/gdstring.tmpl.pxi
@@ -170,15 +170,13 @@ cdef class GDString:
 {% endblock %}
 
 {% block python_defs %}
-    if gdapi10 != NULL:
-        def __init__(self, str pystr=None):
-            if not pystr:
-                gdapi10.godot_string_new(&self._gd_data)
-            else:
-                pyobj_to_godot_string(pystr, &self._gd_data)
-    else:
-        def __init__(self, str pystr=None):
+    def __init__(self, str pystr=None):
+        if gdapi10 == NULL:
             return
+        if not pystr:
+            gdapi10.godot_string_new(&self._gd_data)
+        else:
+            pyobj_to_godot_string(pystr, &self._gd_data)
 
     if gdapi10 != NULL:
         def __dealloc__(GDString self):

--- a/tools/builtins_templates/gdstring.tmpl.pxi
+++ b/tools/builtins_templates/gdstring.tmpl.pxi
@@ -180,10 +180,14 @@ cdef class GDString:
         def __init__(self, str pystr=None):
             return
 
-    def __dealloc__(GDString self):
-        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-        # hand otherwise we will get a segfault here
-        gdapi10.godot_string_destroy(&self._gd_data)
+    if gdapi10 != NULL:
+        def __dealloc__(GDString self):
+            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+            # hand otherwise we will get a segfault here
+            gdapi10.godot_string_destroy(&self._gd_data)
+    else:
+        def __dealloc__(GDString self):
+            return
 
     def __repr__(GDString self):
         return f"<GDString({str(self)!r})>"

--- a/tools/builtins_templates/gdstring.tmpl.pxi
+++ b/tools/builtins_templates/gdstring.tmpl.pxi
@@ -170,11 +170,15 @@ cdef class GDString:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, str pystr=None):
-        if not pystr:
-            gdapi10.godot_string_new(&self._gd_data)
-        else:
-            pyobj_to_godot_string(pystr, &self._gd_data)
+    if gdapi10 != NULL:
+        def __init__(self, str pystr=None):
+            if not pystr:
+                gdapi10.godot_string_new(&self._gd_data)
+            else:
+                pyobj_to_godot_string(pystr, &self._gd_data)
+    else:
+        def __init__(self, str pystr=None):
+            return
 
     def __dealloc__(GDString self):
         # /!\ if `__init__` is skipped, `_gd_data` must be initialized by

--- a/tools/builtins_templates/node_path.tmpl.pxi
+++ b/tools/builtins_templates/node_path.tmpl.pxi
@@ -46,10 +46,14 @@ cdef class NodePath:
         def __init__(self, from_):
             pass
 
-    def __dealloc__(NodePath self):
-        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-        # hand otherwise we will get a segfault here
-        gdapi10.godot_node_path_destroy(&self._gd_data)
+    if gdapi10 != NULL:
+        def __dealloc__(NodePath self):
+            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+            # hand otherwise we will get a segfault here
+            gdapi10.godot_node_path_destroy(&self._gd_data)
+    else:
+        def __dealloc__(NodePath self):
+            return
 
     def __repr__(NodePath self):
         return f"<NodePath({self.as_string()})>"

--- a/tools/builtins_templates/node_path.tmpl.pxi
+++ b/tools/builtins_templates/node_path.tmpl.pxi
@@ -31,20 +31,18 @@ cdef class NodePath:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, from_):
-            cdef godot_string gd_from
-            try:
-                gdapi10.godot_node_path_new(&self._gd_data, &(<GDString?>from_)._gd_data)
-            except TypeError:
-                if not isinstance(from_, str):
-                    raise TypeError("`from_` must be str or GDString")
-                pyobj_to_godot_string(from_, &gd_from)
-                gdapi10.godot_node_path_new(&self._gd_data, &gd_from)
-                gdapi10.godot_string_destroy(&gd_from)
-    else:
-        def __init__(self, from_):
-            pass
+    def __init__(self, from_):
+        if gdapi10 == NULL:
+            return
+        cdef godot_string gd_from
+        try:
+            gdapi10.godot_node_path_new(&self._gd_data, &(<GDString?>from_)._gd_data)
+        except TypeError:
+            if not isinstance(from_, str):
+                raise TypeError("`from_` must be str or GDString")
+            pyobj_to_godot_string(from_, &gd_from)
+            gdapi10.godot_node_path_new(&self._gd_data, &gd_from)
+            gdapi10.godot_string_destroy(&gd_from)
 
     if gdapi10 != NULL:
         def __dealloc__(NodePath self):

--- a/tools/builtins_templates/node_path.tmpl.pxi
+++ b/tools/builtins_templates/node_path.tmpl.pxi
@@ -44,14 +44,12 @@ cdef class NodePath:
             gdapi10.godot_node_path_new(&self._gd_data, &gd_from)
             gdapi10.godot_string_destroy(&gd_from)
 
-    if gdapi10 != NULL:
-        def __dealloc__(NodePath self):
-            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-            # hand otherwise we will get a segfault here
-            gdapi10.godot_node_path_destroy(&self._gd_data)
-    else:
-        def __dealloc__(NodePath self):
+    def __dealloc__(NodePath self):
+        if gdapi10 == NULL:
             return
+        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+        # hand otherwise we will get a segfault here
+        gdapi10.godot_node_path_destroy(&self._gd_data)
 
     def __repr__(NodePath self):
         return f"<NodePath({self.as_string()})>"

--- a/tools/builtins_templates/node_path.tmpl.pxi
+++ b/tools/builtins_templates/node_path.tmpl.pxi
@@ -30,16 +30,21 @@ cdef class NodePath:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, from_):
-        cdef godot_string gd_from
-        try:
-            gdapi10.godot_node_path_new(&self._gd_data, &(<GDString?>from_)._gd_data)
-        except TypeError:
-            if not isinstance(from_, str):
-                raise TypeError("`from_` must be str or GDString")
-            pyobj_to_godot_string(from_, &gd_from)
-            gdapi10.godot_node_path_new(&self._gd_data, &gd_from)
-            gdapi10.godot_string_destroy(&gd_from)
+
+    if gdapi10 != NULL:
+        def __init__(self, from_):
+            cdef godot_string gd_from
+            try:
+                gdapi10.godot_node_path_new(&self._gd_data, &(<GDString?>from_)._gd_data)
+            except TypeError:
+                if not isinstance(from_, str):
+                    raise TypeError("`from_` must be str or GDString")
+                pyobj_to_godot_string(from_, &gd_from)
+                gdapi10.godot_node_path_new(&self._gd_data, &gd_from)
+                gdapi10.godot_string_destroy(&gd_from)
+    else:
+        def __init__(self, from_):
+            pass
 
     def __dealloc__(NodePath self):
         # /!\ if `__init__` is skipped, `_gd_data` must be initialized by

--- a/tools/builtins_templates/plane.tmpl.pxi
+++ b/tools/builtins_templates/plane.tmpl.pxi
@@ -37,8 +37,14 @@ cdef class Plane:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
-        gdapi10.godot_plane_new_with_reals(&self._gd_data, a, b, c, d)
+
+    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
+    if gdapi10 != NULL:
+        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+            gdapi10.godot_plane_new_with_reals(&self._gd_data, a, b, c, d)
+    else:
+        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+            return
 
     @staticmethod
     def from_vectors(Vector3 v1 not None, Vector3 v2 not None, Vector3 v3 not None):

--- a/tools/builtins_templates/plane.tmpl.pxi
+++ b/tools/builtins_templates/plane.tmpl.pxi
@@ -38,13 +38,10 @@ cdef class Plane:
 
 {% block python_defs %}
 
-    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
-    if gdapi10 != NULL:
-        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
-            gdapi10.godot_plane_new_with_reals(&self._gd_data, a, b, c, d)
-    else:
-        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+    def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_plane_new_with_reals(&self._gd_data, a, b, c, d)
 
     @staticmethod
     def from_vectors(Vector3 v1 not None, Vector3 v2 not None, Vector3 v3 not None):

--- a/tools/builtins_templates/quat.tmpl.pxi
+++ b/tools/builtins_templates/quat.tmpl.pxi
@@ -48,14 +48,12 @@ cdef class Quat:
 
 {% block python_defs %}
 
-    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
-    if gdapi10 != NULL:
-        def __init__(self, x=0, y=0, z=0, w=0):
-            gdapi10.godot_quat_new(&self._gd_data, x, y, z, w)
-    else:
-        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+    
+    def __init__(self, x=0, y=0, z=0, w=0):
+        if gdapi10 == NULL:
             return
-
+        gdapi10.godot_quat_new(&self._gd_data, x, y, z, w)
+    
     @staticmethod
     def from_axis_angle(Vector3 axis not None, godot_real angle):
         # Call to __new__ bypasses __init__ constructor

--- a/tools/builtins_templates/quat.tmpl.pxi
+++ b/tools/builtins_templates/quat.tmpl.pxi
@@ -47,8 +47,14 @@ cdef class Quat:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, x=0, y=0, z=0, w=0):
-        gdapi10.godot_quat_new(&self._gd_data, x, y, z, w)
+
+    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
+    if gdapi10 != NULL:
+        def __init__(self, x=0, y=0, z=0, w=0):
+            gdapi10.godot_quat_new(&self._gd_data, x, y, z, w)
+    else:
+        def __init__(self, godot_real a, godot_real b, godot_real c, godot_real d):
+            return
 
     @staticmethod
     def from_axis_angle(Vector3 axis not None, godot_real angle):

--- a/tools/builtins_templates/rect2.tmpl.pxi
+++ b/tools/builtins_templates/rect2.tmpl.pxi
@@ -37,8 +37,12 @@ cdef class Rect2:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
-        gdapi10.godot_rect2_new(&self._gd_data, x, y, width, height)
+    if gdapi10 != NULL:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
+            gdapi10.godot_rect2_new(&self._gd_data, x, y, width, height)
+    else:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
+            return
 
     @staticmethod
     def from_pos_size(Vector2 position not None, Vector2 size not None):

--- a/tools/builtins_templates/rect2.tmpl.pxi
+++ b/tools/builtins_templates/rect2.tmpl.pxi
@@ -37,12 +37,11 @@ cdef class Rect2:
 {% endblock %}
 
 {% block python_defs %}
-    if gdapi10 != NULL:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
-            gdapi10.godot_rect2_new(&self._gd_data, x, y, width, height)
-    else:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
+
+    def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real width=0.0, godot_real height=0.0):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_rect2_new(&self._gd_data, x, y, width, height)
 
     @staticmethod
     def from_pos_size(Vector2 position not None, Vector2 size not None):

--- a/tools/builtins_templates/rid.tmpl.pxi
+++ b/tools/builtins_templates/rid.tmpl.pxi
@@ -24,18 +24,16 @@ cdef class RID:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, Resource from_=None):
-            if from_ is not None:
-                gdapi10.godot_rid_new_with_resource(
-                    &self._gd_data,
-                    from_._gd_ptr
-                )
-            else:
-                gdapi10.godot_rid_new(&self._gd_data)
-    else:
-        def __init__(self, Resource from_=None):
+    def __init__(self, Resource from_=None):
+        if gdapi10 == NULL:
             return
+        if from_ is not None:
+            gdapi10.godot_rid_new_with_resource(
+                &self._gd_data,
+                from_._gd_ptr
+            )
+        else:
+            gdapi10.godot_rid_new(&self._gd_data)
 
     def __repr__(RID self):
         return f"<RID(id={self.get_id()})>"

--- a/tools/builtins_templates/rid.tmpl.pxi
+++ b/tools/builtins_templates/rid.tmpl.pxi
@@ -23,14 +23,19 @@ cdef class RID:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, Resource from_=None):
-        if from_ is not None:
-            gdapi10.godot_rid_new_with_resource(
-                &self._gd_data,
-                from_._gd_ptr
-            )
-        else:
-            gdapi10.godot_rid_new(&self._gd_data)
+
+    if gdapi10 != NULL:
+        def __init__(self, Resource from_=None):
+            if from_ is not None:
+                gdapi10.godot_rid_new_with_resource(
+                    &self._gd_data,
+                    from_._gd_ptr
+                )
+            else:
+                gdapi10.godot_rid_new(&self._gd_data)
+    else:
+        def __init__(self, Resource from_=None):
+            return
 
     def __repr__(RID self):
         return f"<RID(id={self.get_id()})>"

--- a/tools/builtins_templates/transform.tmpl.pxi
+++ b/tools/builtins_templates/transform.tmpl.pxi
@@ -41,17 +41,22 @@ cdef class Transform:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
-        if x_axis is None and y_axis is None and z_axis is None and origin is None:
-            gdapi10.godot_transform_new_identity(&self._gd_data)
-        else:
-            gdapi10.godot_transform_new_with_axis_origin(
-                &self._gd_data,
-                &(<Vector3?>x_axis)._gd_data,
-                &(<Vector3?>y_axis)._gd_data,
-                &(<Vector3?>z_axis)._gd_data,
-                &(<Vector3?>origin)._gd_data,
-            )
+
+    if gdapi10 != NULL:
+        def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
+            if x_axis is None and y_axis is None and z_axis is None and origin is None:
+                gdapi10.godot_transform_new_identity(&self._gd_data)
+            else:
+                gdapi10.godot_transform_new_with_axis_origin(
+                    &self._gd_data,
+                    &(<Vector3?>x_axis)._gd_data,
+                    &(<Vector3?>y_axis)._gd_data,
+                    &(<Vector3?>z_axis)._gd_data,
+                    &(<Vector3?>origin)._gd_data,
+                )
+    else:
+        def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
+            return
 
     @staticmethod
     def from_basis_origin(Basis basis not None, Vector3 origin not None):

--- a/tools/builtins_templates/transform.tmpl.pxi
+++ b/tools/builtins_templates/transform.tmpl.pxi
@@ -42,21 +42,20 @@ cdef class Transform:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
-            if x_axis is None and y_axis is None and z_axis is None and origin is None:
-                gdapi10.godot_transform_new_identity(&self._gd_data)
-            else:
-                gdapi10.godot_transform_new_with_axis_origin(
-                    &self._gd_data,
-                    &(<Vector3?>x_axis)._gd_data,
-                    &(<Vector3?>y_axis)._gd_data,
-                    &(<Vector3?>z_axis)._gd_data,
-                    &(<Vector3?>origin)._gd_data,
-                )
-    else:
-        def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
+
+    def __init__(self, x_axis=None, y_axis=None, z_axis=None, origin=None):
+        if gdapi10 == NULL:
             return
+        if x_axis is None and y_axis is None and z_axis is None and origin is None:
+            gdapi10.godot_transform_new_identity(&self._gd_data)
+        else:
+            gdapi10.godot_transform_new_with_axis_origin(
+                &self._gd_data,
+                &(<Vector3?>x_axis)._gd_data,
+                &(<Vector3?>y_axis)._gd_data,
+                &(<Vector3?>z_axis)._gd_data,
+                &(<Vector3?>origin)._gd_data,
+            )
 
     @staticmethod
     def from_basis_origin(Basis basis not None, Vector3 origin not None):

--- a/tools/builtins_templates/transform2d.tmpl.pxi
+++ b/tools/builtins_templates/transform2d.tmpl.pxi
@@ -39,16 +39,21 @@ cdef class Transform2D:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, x_axis=None, y_axis=None, origin=None):
-        if x_axis is None and y_axis is None and origin is None:
-            gdapi10.godot_transform2d_new_identity(&self._gd_data)
-        else:
-            gdapi10.godot_transform2d_new_axis_origin(
-                &self._gd_data,
-                &(<Vector2?>x_axis)._gd_data,
-                &(<Vector2?>y_axis)._gd_data,
-                &(<Vector2?>origin)._gd_data,
-            )
+
+    if gdapi10 != NULL:
+        def __init__(self, x_axis=None, y_axis=None, origin=None):
+            if x_axis is None and y_axis is None and origin is None:
+                gdapi10.godot_transform2d_new_identity(&self._gd_data)
+            else:
+                gdapi10.godot_transform2d_new_axis_origin(
+                    &self._gd_data,
+                    &(<Vector2?>x_axis)._gd_data,
+                    &(<Vector2?>y_axis)._gd_data,
+                    &(<Vector2?>origin)._gd_data,
+                )
+    else:
+        def __init__(self, x_axis=None, y_axis=None, origin=None):
+            return
 
     @staticmethod
     def from_rot_pos(godot_real rot, Vector2 pos not None):

--- a/tools/builtins_templates/transform2d.tmpl.pxi
+++ b/tools/builtins_templates/transform2d.tmpl.pxi
@@ -40,20 +40,18 @@ cdef class Transform2D:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, x_axis=None, y_axis=None, origin=None):
-            if x_axis is None and y_axis is None and origin is None:
-                gdapi10.godot_transform2d_new_identity(&self._gd_data)
-            else:
-                gdapi10.godot_transform2d_new_axis_origin(
-                    &self._gd_data,
-                    &(<Vector2?>x_axis)._gd_data,
-                    &(<Vector2?>y_axis)._gd_data,
-                    &(<Vector2?>origin)._gd_data,
-                )
-    else:
-        def __init__(self, x_axis=None, y_axis=None, origin=None):
+    def __init__(self, x_axis=None, y_axis=None, origin=None):
+        if gdapi10 == NULL:
             return
+        if x_axis is None and y_axis is None and origin is None:
+            gdapi10.godot_transform2d_new_identity(&self._gd_data)
+        else:
+            gdapi10.godot_transform2d_new_axis_origin(
+                &self._gd_data,
+                &(<Vector2?>x_axis)._gd_data,
+                &(<Vector2?>y_axis)._gd_data,
+                &(<Vector2?>origin)._gd_data,
+            )
 
     @staticmethod
     def from_rot_pos(godot_real rot, Vector2 pos not None):

--- a/tools/builtins_templates/vector2.tmpl.pxi
+++ b/tools/builtins_templates/vector2.tmpl.pxi
@@ -76,8 +76,13 @@ cdef class Vector2:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, godot_real x=0.0, godot_real y=0.0):
-        gdapi10.godot_vector2_new(&self._gd_data, x, y)
+
+    if gdapi10 != NULL:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0):
+            gdapi10.godot_vector2_new(&self._gd_data, x, y)
+    else:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0):
+            return
 
     def __repr__(Vector2 self):
         return f"<Vector2(x={self.x}, y={self.y})>"

--- a/tools/builtins_templates/vector2.tmpl.pxi
+++ b/tools/builtins_templates/vector2.tmpl.pxi
@@ -77,12 +77,10 @@ cdef class Vector2:
 
 {% block python_defs %}
 
-    if gdapi10 != NULL:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0):
-            gdapi10.godot_vector2_new(&self._gd_data, x, y)
-    else:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0):
+    def __init__(self, godot_real x=0.0, godot_real y=0.0):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_vector2_new(&self._gd_data, x, y)
 
     def __repr__(Vector2 self):
         return f"<Vector2(x={self.x}, y={self.y})>"

--- a/tools/builtins_templates/vector3.tmpl.pxi
+++ b/tools/builtins_templates/vector3.tmpl.pxi
@@ -82,12 +82,11 @@ cdef class Vector3:
 {% block python_defs %}
     
     # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
-    if gdapi10 != NULL:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
-            gdapi10.godot_vector3_new(&self._gd_data, x, y, z)
-    else:
-        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
+    
+    def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
+        if gdapi10 == NULL:
             return
+        gdapi10.godot_vector3_new(&self._gd_data, x, y, z)
     
     def __repr__(self):
         return f"<Vector3(x={self.x}, y={self.y}, z={self.z})>"

--- a/tools/builtins_templates/vector3.tmpl.pxi
+++ b/tools/builtins_templates/vector3.tmpl.pxi
@@ -80,9 +80,15 @@ cdef class Vector3:
 {% endblock %}
 
 {% block python_defs %}
-    def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
-        gdapi10.godot_vector3_new(&self._gd_data, x, y, z)
-
+    
+    # This check can be made at import time, thus we avoid putting a branch inside init, which may be in the hot path.
+    if gdapi10 != NULL:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
+            gdapi10.godot_vector3_new(&self._gd_data, x, y, z)
+    else:
+        def __init__(self, godot_real x=0.0, godot_real y=0.0, godot_real z=0.0):
+            return
+    
     def __repr__(self):
         return f"<Vector3(x={self.x}, y={self.y}, z={self.z})>"
 

--- a/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
+++ b/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
@@ -14,32 +14,30 @@ gdapi10.godot_string_destroy(&src)
 @cython.final
 cdef class {{ t.py_pool }}:
 
-    if gdapi10 != NULL:
-        def __init__(self, other=None):
-            cdef {{ t.py_pool }} other_as_pool_array
-            cdef Array other_as_array
-            if other is None:
-                gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
-            else:
+    def __init__(self, other=None):
+        if gdapi10 == NULL:
+            return
+        cdef {{ t.py_pool }} other_as_pool_array
+        cdef Array other_as_array
+        if other is None:
+            gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
+        else:
+            try:
+                other_as_pool_array = <{{ t.py_pool }}?>other
+                gdapi10.{{ t.gd_pool }}_new_copy(&self._gd_data, &other_as_pool_array._gd_data)
+            except TypeError:
                 try:
-                    other_as_pool_array = <{{ t.py_pool }}?>other
-                    gdapi10.{{ t.gd_pool }}_new_copy(&self._gd_data, &other_as_pool_array._gd_data)
+                    other_as_array = <Array?>other
+                    gdapi10.{{ t.gd_pool }}_new_with_array(&self._gd_data, &other_as_array._gd_data)
                 except TypeError:
-                    try:
-                        other_as_array = <Array?>other
-                        gdapi10.{{ t.gd_pool }}_new_with_array(&self._gd_data, &other_as_array._gd_data)
-                    except TypeError:
-                        gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
-                        for item in other:
+                    gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
+                    for item in other:
 {% if t.is_base_type %}
-                            {{ t.py_pool }}.append(self, item)
+                        {{ t.py_pool }}.append(self, item)
 {% else %}
-                            {{ t.py_pool }}.append(self, (<{{ t.py_value }}?>item))
+                        {{ t.py_pool }}.append(self, (<{{ t.py_value }}?>item))
 {% endif %}
 
-    else:
-        def __init__(self, other=None):
-            return
 
     if gdapi10 != NULL:
         def __dealloc__(self):

--- a/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
+++ b/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
@@ -41,10 +41,14 @@ cdef class {{ t.py_pool }}:
         def __init__(self, other=None):
             return
 
-    def __dealloc__(self):
-        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-        # hand otherwise we will get a segfault here
-        gdapi10.{{ t.gd_pool }}_destroy(&self._gd_data)
+    if gdapi10 != NULL:
+        def __dealloc__(self):
+            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+            # hand otherwise we will get a segfault here
+            gdapi10.{{ t.gd_pool }}_destroy(&self._gd_data)
+    else:
+        def __dealloc__(self):
+            return
 
     @staticmethod
     cdef inline {{ t.py_pool }} new():

--- a/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
+++ b/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
@@ -14,27 +14,32 @@ gdapi10.godot_string_destroy(&src)
 @cython.final
 cdef class {{ t.py_pool }}:
 
-    def __init__(self, other=None):
-        cdef {{ t.py_pool }} other_as_pool_array
-        cdef Array other_as_array
-        if other is None:
-            gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
-        else:
-            try:
-                other_as_pool_array = <{{ t.py_pool }}?>other
-                gdapi10.{{ t.gd_pool }}_new_copy(&self._gd_data, &other_as_pool_array._gd_data)
-            except TypeError:
+    if gdapi10 != NULL:
+        def __init__(self, other=None):
+            cdef {{ t.py_pool }} other_as_pool_array
+            cdef Array other_as_array
+            if other is None:
+                gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
+            else:
                 try:
-                    other_as_array = <Array?>other
-                    gdapi10.{{ t.gd_pool }}_new_with_array(&self._gd_data, &other_as_array._gd_data)
+                    other_as_pool_array = <{{ t.py_pool }}?>other
+                    gdapi10.{{ t.gd_pool }}_new_copy(&self._gd_data, &other_as_pool_array._gd_data)
                 except TypeError:
-                    gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
-                    for item in other:
+                    try:
+                        other_as_array = <Array?>other
+                        gdapi10.{{ t.gd_pool }}_new_with_array(&self._gd_data, &other_as_array._gd_data)
+                    except TypeError:
+                        gdapi10.{{ t.gd_pool }}_new(&self._gd_data)
+                        for item in other:
 {% if t.is_base_type %}
-                        {{ t.py_pool }}.append(self, item)
+                            {{ t.py_pool }}.append(self, item)
 {% else %}
-                        {{ t.py_pool }}.append(self, (<{{ t.py_value }}?>item))
+                            {{ t.py_pool }}.append(self, (<{{ t.py_value }}?>item))
 {% endif %}
+
+    else:
+        def __init__(self, other=None):
+            return
 
     def __dealloc__(self):
         # /!\ if `__init__` is skipped, `_gd_data` must be initialized by

--- a/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
+++ b/tools/pool_arrays_templates/pool_x_array.tmpl.pyx
@@ -39,14 +39,12 @@ cdef class {{ t.py_pool }}:
 {% endif %}
 
 
-    if gdapi10 != NULL:
-        def __dealloc__(self):
-            # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
-            # hand otherwise we will get a segfault here
-            gdapi10.{{ t.gd_pool }}_destroy(&self._gd_data)
-    else:
-        def __dealloc__(self):
+    def __dealloc__(self):
+        if gdapi10 == NULL:
             return
+        # /!\ if `__init__` is skipped, `_gd_data` must be initialized by
+        # hand otherwise we will get a segfault here
+        gdapi10.{{ t.gd_pool }}_destroy(&self._gd_data)
 
     @staticmethod
     cdef inline {{ t.py_pool }} new():


### PR DESCRIPTION
This PR makes some checks for the availability of gdapi10 instead of trying to access it when it's null, causing a segfault.
Fixes #174 
Problem:
```
Python 3.8.3 (default, May 18 2020, 00:17:26) 
[Clang 10.0.0 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import godot
Segmentation fault      (core dumped) ./addons/pythonscript/x11-64/bin/python3
```

Importing godot from the python interpreter, without being imported as a GDNative extension cause the interpreter to segfault because pythonscript_gdapi10 was not set (NULL).
Thus, the library wasn't importable by IDEs like PyCharm or VSCode, and those weren't able to provide code completions.
With this PR, most of the builtins get their `__init__` replaced by a dummy one when gdapi10 is not available. The library will be essentially unusable because it cant interface with godot, but it imports, and that is enough for introspection and code completion.