### PR TITLE
Allow for cython methods in scripts

### DIFF
--- a/pythonscript/_godot_script.pxi
+++ b/pythonscript/_godot_script.pxi
@@ -121,7 +121,7 @@ cdef godot_pluginscript_script_manifest _build_script_manifest(object cls):
     # for methname in vars(cls):
     for methname in dir(cls):
         meth = getattr(cls, methname)
-        if not inspect.isfunction(meth) or meth.__name__.startswith("__"):
+        if not callable(meth) or meth.__name__.startswith("__"):
             continue
         methods.append(_build_method_info(meth, methname))
     gdapi10.godot_array_new_copy(&manifest.methods, &methods._gd_data)

--- a/pythonscript/_godot_script.pxi
+++ b/pythonscript/_godot_script.pxi
@@ -94,6 +94,14 @@ cdef Dictionary _build_property_info(object prop):
     propinfo["rset_mode"] = prop.rpc
     return propinfo
 
+cdef inline object is_method(object meth):
+    if inspect.isfunction(meth):
+        return True
+    
+    if 'cython_function' in type(meth).__name__:
+        return True
+    
+    return False
 
 cdef godot_pluginscript_script_manifest _build_script_manifest(object cls):
     cdef godot_pluginscript_script_manifest manifest
@@ -121,7 +129,7 @@ cdef godot_pluginscript_script_manifest _build_script_manifest(object cls):
     # for methname in vars(cls):
     for methname in dir(cls):
         meth = getattr(cls, methname)
-        if not callable(meth) or meth.__name__.startswith("__"):
+        if not is_method(meth) or meth.__name__.startswith("__") or methname.startswith('__'):
             continue
         methods.append(_build_method_info(meth, methname))
     gdapi10.godot_array_new_copy(&manifest.methods, &methods._gd_data)


### PR DESCRIPTION
`inspect.isfunction()` returns `False` for Cython functions and methods.
I tried using `callable` for the check but it results in a flood of other stuff that would end up causing trouble.