### PR TITLE
Add sanity check to prevent loading godot module from regular Python …

### DIFF
--- a/pythonscript/godot/__init__.py
+++ b/pythonscript/godot/__init__.py
@@ -1,3 +1,18 @@
+# Start with a sanity check to ensure the loading is done from Godot-Python
+# (and not from a regular Python interpreter which would lead to a segfault).
+# The idea is we should have the following loading order:
+# godot binary -> pythonscript.so -> _godot.so -> godot/__init__.py
+import sys
+
+if "_godot" not in sys.modules:
+    raise ImportError(
+        "Cannot initialize godot module given Godot GDNative API not available.\n"
+        "This is most likely because you are running code from a regular Python interpreter"
+        " (i.e. doing something like `python my_script.py`) while godot module is only available"
+        " to Python code loaded from Godot through Godot-Python plugin."
+    )
+del sys
+
 from godot._version import __version__
 from godot.tags import (
     MethodRPCMode,

--- a/tests/python_binary/SConscript
+++ b/tests/python_binary/SConscript
@@ -67,6 +67,21 @@ def test_factory(target, cmd):
 test_factory("run_python", f"{python} --version")
 
 
+test_factory(
+    "import_godot_module",
+    [
+        python,
+        "-c",
+        """
+try:
+    import godot
+except ImportError as exc:
+    assert "Cannot initialize godot module given Godot GDNative API not available." in str(exc)
+""",
+    ],
+)
+
+
 def test_ensurepip_and_run_pip(target, source, env):
     # ensurepip does modification, so copy dist first
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
…interpreter (which would end up in segfault...)