### PR TITLE
tuning x11-64 platform for aarch64 and pyhton3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@ Godot Python, because you want Python on Godot !
 The goal of this project is to provide Python language support as a scripting
 module for the `Godot <http://godotengine.org>`_ game engine.
 
+Notes
+====
+
+This version is a hack to build godot-python on aarch64 (tested on RaspberryPi 4 2GB, swap maxxed out to 11+GB, Raspberry Pi OS / Debian 10.5), replacing platform x11-64. Before launching the build with the usual instructions below, grab manually an aarch64 build from `python-build-standalone project <https://github.com/indygreg/python-build-standalone/>`_ under the CI menu ("actions") -- aarch64 linux is not part of official releases and only comes with python3.9 as of 2021-05-30. Prefer a version without debug and optimisations, e.g. "lto". Place the .tar.zst package in ``/tmp/cpython-3.9.5-aarch64-unknown-linux-gnu.tar.zst``. Compilation will likely take hours.
 
 Quickstart
 ==========

--- a/platforms/x11-64/SConscript
+++ b/platforms/x11-64/SConscript
@@ -19,17 +19,17 @@ else:
     env["godot_binary_download_platform"] = "x11.64"
 env["cpython_build"] = cpython_build
 env["cpython_build_dir"] = cpython_build
-env["DIST_SITE_PACKAGES"] = Dir(f"{env['DIST_PLATFORM']}/lib/python3.8/site-packages")
+env["DIST_SITE_PACKAGES"] = Dir(f"{env['DIST_PLATFORM']}/lib/python3.9/site-packages")
 
 
 ### Build config for pythonscript ###
 
 
-env.AppendUnique(CFLAGS=["-m64"])
-env.AppendUnique(LINKFLAGS=["-m64"])
+#env.AppendUnique(CFLAGS=["-m64"])
+#env.AppendUnique(LINKFLAGS=["-m64"])
 # Cannot use CPPPATH&LIBPATH here given headers are within `cpython_build` target,
 # so Scons consider the headers are a missing target
-env.AppendUnique(CFLAGS=[f"-I{cpython_build.abspath}/include/python3.8/"])
+env.AppendUnique(CFLAGS=[f"-I{cpython_build.abspath}/include/python3.9/"])
 env.AppendUnique(LINKFLAGS=[f"-L{cpython_build.abspath}/lib"])
 env.AppendUnique(CYTHON_COMPILE_DEPS=[cpython_build])
 
@@ -37,7 +37,9 @@ env.AppendUnique(CYTHON_COMPILE_DEPS=[cpython_build])
 ### Fetch Python prebuild ###
 
 
-CPYTHON_PREBUILD_URL = "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst"
+#CPYTHON_PREBUILD_URL = "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst"
+# download manually a binary for aarch64-unknown-linux-gnu and place it in /tmp/ E.g. grab a release or CI artifacts from https://github.com/indygreg/python-build-standalone -- prefer a version with optimisations and no debug, i.e. "lto"
+PYTHON_PREBUILD_URL = "file:///tmp/cpython-3.9.5-aarch64-unknown-linux-gnu.tar.zst"
 cpython_prebuild_archive = env.Download(
     target=File(CPYTHON_PREBUILD_URL.rsplit("/", 1)[1]), url=CPYTHON_PREBUILD_URL
 )
@@ -71,9 +73,9 @@ def generate_cpython_build(target, source, env):
     prebuild = Path(source[0].abspath) / "python"
 
     conf = json.loads((prebuild / "PYTHON.json").read_text())
-    assert conf["version"] == "5"
+    assert conf["version"] == "7"
     assert conf["libpython_link_mode"] == "shared"
-    assert conf["target_triple"] == "x86_64-unknown-linux-gnu"
+    assert conf["target_triple"] == "aarch64-unknown-linux-gnu"
 
     shutil.copytree(str(prebuild / "install"), str(build), symlinks=True)
     shutil.copytree(str(prebuild / "licenses"), str(build / "licenses"), symlinks=True)
@@ -87,7 +89,7 @@ def generate_cpython_build(target, source, env):
     assert config.exists()
     shutil.rmtree(str(config))
 
-    stdlib_path = build / "lib/python3.8"
+    stdlib_path = build / "lib/python3.9"
 
     # Remove tests lib (pretty big and basically useless)
     shutil.rmtree(str(stdlib_path / "test"))
@@ -101,12 +103,12 @@ def generate_cpython_build(target, source, env):
 
     # Zip the stdlib to save plenty of space \o/
     if env["compressed_stdlib"]:
-        tmp_stdlib_path = build / "lib/tmp_python3.8"
+        tmp_stdlib_path = build / "lib/tmp_python3.9"
         shutil.move(str(stdlib_path), str(tmp_stdlib_path))
         stdlib_path.mkdir()
         shutil.move(str(tmp_stdlib_path / "lib-dynload"), str(stdlib_path / "lib-dynload"))
         shutil.make_archive(
-            base_name=build / "lib/python38", format="zip", root_dir=str(tmp_stdlib_path)
+            base_name=build / "lib/python39", format="zip", root_dir=str(tmp_stdlib_path)
         )
         shutil.rmtree(str(tmp_stdlib_path))
         # Oddly enough, os.py must be present (even if empty !) otherwise

--- a/pythonscript/SConscript
+++ b/pythonscript/SConscript
@@ -14,7 +14,7 @@ elif env["platform"].startswith("osx"):
     c_env.AppendUnique(CFLAGS=["-Werror-implicit-function-declaration"])
 
 else:  # x11
-    c_env.AppendUnique(LIBS=["python3.8"])
+    c_env.AppendUnique(LIBS=["python3.9"])
     c_env.AppendUnique(LINKFLAGS=["-Wl,-rpath,'$$ORIGIN/lib'"])
     c_env.AppendUnique(CFLAGS=["-Werror-implicit-function-declaration"])
 c_env.Depends("pythonscript.c", env["cpython_build"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ appdirs==1.4.4 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via black
 autopxd2==1.1.0 \
-    --hash=sha256:faa4b7eeb6b1d7217c46d3660640d4a72fb5c86d4559017c1f58a55d34332b2a
+    --hash=sha256:687d77b167020354c0e7d0d47b906494fb9004a74ca3c80a479c83d8cbe6eee1
     # via -r requirements.in
 black==20.8b1 \
     --hash=sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea

--- a/site_scons/site_tools/cython.py
+++ b/site_scons/site_tools/cython.py
@@ -98,7 +98,7 @@ def CythonCompile(env, target, source):
             SHLIBSUFFIX=".so",
             CFLAGS=cflags,
             LINKFLAGS=[*linkflags, *env["LINKFLAGS"]],
-            LIBS=["python3.8", "pythonscript"],
+            LIBS=["python3.9", "pythonscript"],
             # LIBS=[*env["CYTHON_LIBS"], *env["LIBS"]],
             # LIBPATH=[*env['CYTHON_LIBPATH'], *env['LIBPATH']]
         )


### PR DESCRIPTION
Hello,

First of all, thank you for this project, this is amazing that we can run Python scripts within Godot. I only scratched the surface but it already open many doors, not only for the language per se, but because there tons of libraries that can be now be employed alongside the game engine.

Some weeks ago I tried to run godot-python on Raspberry Pi (Raspberry Pi OS / Debian Buster). It failed because this is not something that is planned in current code, and because aarch64 was only recently added to the underlying python-build-standalone (and it is still a work in progress).

After some time hacking my way through the code, I managed nonetheless to make it work. I added some instructions in the README, the broader picture is detailed in a tutorial here https://labs.ullo.fr/tutorials/python-and-godot-engine-on-a-raspberry-pi-displaying-physiological-signals-with-lsl/  Note that only python 3.9, not 3.8, is supported by python-build-standalone for aarch64. It did not seem to be an issue but I did not test thoroughly every feature of godot-python.

This pull request is not to be merged as is, because I went fast and simply replaced the existing x11-64 platform. Now, others might be interested in running and Godot and Python on a Raspberry (or on other aarch64 linux systems). What would be the best way to integrate those changes? Create a dedicated platform, e.g. x11-64-arm (maybe with an "-experimental"  flag)?
