### PR TITLE
upgrade to python3.10 -- x11-64 only

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -53,7 +53,7 @@ vars.Add("release_suffix", "Suffix to add to the release archive", extract_versi
 vars.Add(
     "godot_binary",
     "Path to Godot binary or version of Godot to use",
-    default="3.2.2",
+    default="3.4.4",
     converter=godot_binary_converter,
 )
 vars.Add("godot_headers", "Path to Godot GDnative headers", "")

--- a/platforms/x11-64/SConscript
+++ b/platforms/x11-64/SConscript
@@ -19,17 +19,17 @@ else:
     env["godot_binary_download_platform"] = "x11.64"
 env["cpython_build"] = cpython_build
 env["cpython_build_dir"] = cpython_build
-env["DIST_SITE_PACKAGES"] = Dir(f"{env['DIST_PLATFORM']}/lib/python3.8/site-packages")
+env["DIST_SITE_PACKAGES"] = Dir(f"{env['DIST_PLATFORM']}/lib/python3.10/site-packages")
 
 
 ### Build config for pythonscript ###
 
 
-env.AppendUnique(CFLAGS=["-m64"])
-env.AppendUnique(LINKFLAGS=["-m64"])
+#env.AppendUnique(CFLAGS=["-m64"])
+#env.AppendUnique(LINKFLAGS=["-m64"])
 # Cannot use CPPPATH&LIBPATH here given headers are within `cpython_build` target,
 # so Scons consider the headers are a missing target
-env.AppendUnique(CFLAGS=[f"-I{cpython_build.abspath}/include/python3.8/"])
+env.AppendUnique(CFLAGS=[f"-I{cpython_build.abspath}/include/python3.10/"])
 env.AppendUnique(LINKFLAGS=[f"-L{cpython_build.abspath}/lib"])
 env.AppendUnique(CYTHON_COMPILE_DEPS=[cpython_build])
 
@@ -37,7 +37,8 @@ env.AppendUnique(CYTHON_COMPILE_DEPS=[cpython_build])
 ### Fetch Python prebuild ###
 
 
-CPYTHON_PREBUILD_URL = "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst"
+
+CPYTHON_PREBUILD_URL = "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4+20220528-x86_64-unknown-linux-gnu-pgo+lto-full.tar.zst"
 cpython_prebuild_archive = env.Download(
     target=File(CPYTHON_PREBUILD_URL.rsplit("/", 1)[1]), url=CPYTHON_PREBUILD_URL
 )
@@ -71,7 +72,7 @@ def generate_cpython_build(target, source, env):
     prebuild = Path(source[0].abspath) / "python"
 
     conf = json.loads((prebuild / "PYTHON.json").read_text())
-    assert conf["version"] == "5"
+    assert conf["version"] == "7"
     assert conf["libpython_link_mode"] == "shared"
     assert conf["target_triple"] == "x86_64-unknown-linux-gnu"
 
@@ -87,7 +88,7 @@ def generate_cpython_build(target, source, env):
     assert config.exists()
     shutil.rmtree(str(config))
 
-    stdlib_path = build / "lib/python3.8"
+    stdlib_path = build / "lib/python3.10"
 
     # Remove tests lib (pretty big and basically useless)
     shutil.rmtree(str(stdlib_path / "test"))
@@ -101,12 +102,12 @@ def generate_cpython_build(target, source, env):
 
     # Zip the stdlib to save plenty of space \o/
     if env["compressed_stdlib"]:
-        tmp_stdlib_path = build / "lib/tmp_python3.8"
+        tmp_stdlib_path = build / "lib/tmp_python3.10"
         shutil.move(str(stdlib_path), str(tmp_stdlib_path))
         stdlib_path.mkdir()
         shutil.move(str(tmp_stdlib_path / "lib-dynload"), str(stdlib_path / "lib-dynload"))
         shutil.make_archive(
-            base_name=build / "lib/python38", format="zip", root_dir=str(tmp_stdlib_path)
+            base_name=build / "lib/python310", format="zip", root_dir=str(tmp_stdlib_path)
         )
         shutil.rmtree(str(tmp_stdlib_path))
         # Oddly enough, os.py must be present (even if empty !) otherwise

--- a/pythonscript/SConscript
+++ b/pythonscript/SConscript
@@ -2,10 +2,10 @@ Import("env")
 
 c_env = env.Clone()
 if env["platform"].startswith("windows"):
-    c_env.AppendUnique(LIBS=["python38"])
+    c_env.AppendUnique(LIBS=["python310"])
 
 elif env["platform"].startswith("osx"):
-    c_env.AppendUnique(LIBS=["python3.8"])
+    c_env.AppendUnique(LIBS=["python3.10"])
     # if we don't give the lib a proper install_name, macos won't be able to find it,
     # and will link the cython modules with a relative path
     c_env.AppendUnique(
@@ -14,7 +14,7 @@ elif env["platform"].startswith("osx"):
     c_env.AppendUnique(CFLAGS=["-Werror-implicit-function-declaration"])
 
 else:  # x11
-    c_env.AppendUnique(LIBS=["python3.8"])
+    c_env.AppendUnique(LIBS=["python3.10"])
     c_env.AppendUnique(LINKFLAGS=["-Wl,-rpath,'$$ORIGIN/lib'"])
     c_env.AppendUnique(CFLAGS=["-Werror-implicit-function-declaration"])
 c_env.Depends("pythonscript.c", env["cpython_build"])

--- a/site_scons/site_tools/cython.py
+++ b/site_scons/site_tools/cython.py
@@ -75,7 +75,7 @@ def CythonCompile(env, target, source):
             LIBPREFIX="",
             SHLIBSUFFIX=".pyd",
             CFLAGS=cflags,
-            LIBS=["python38", "pythonscript"],
+            LIBS=["python310", "pythonscript"],
             # LIBS=[*env["CYTHON_LIBS"], *env["LIBS"]],
             # LIBPATH=[*env['CYTHON_LIBPATH'], *env['LIBPATH']]
         )
@@ -98,7 +98,7 @@ def CythonCompile(env, target, source):
             SHLIBSUFFIX=".so",
             CFLAGS=cflags,
             LINKFLAGS=[*linkflags, *env["LINKFLAGS"]],
-            LIBS=["python3.8", "pythonscript"],
+            LIBS=["python3.10", "pythonscript"],
             # LIBS=[*env["CYTHON_LIBS"], *env["LIBS"]],
             # LIBPATH=[*env['CYTHON_LIBPATH'], *env['LIBPATH']]
         )


### PR DESCRIPTION
can't test anything else

Install py10 for godot 3.4.4

i have to install `libxcrypt-compat` at arch linux

# Thanks to
@touilleMan for godot-python
@jfrey-xx for the Input and great Articel about [Python Integration](https://labs.ullo.fr/tutorials/python-and-godot-engine-on-a-raspberry-pi-displaying-physiological-signals-with-lsl/)

![image](https://user-images.githubusercontent.com/13271923/171277319-2c9cd450-ba89-440e-aba2-d2c571f3742c.png)
